### PR TITLE
ci(preview): deploy pull requests to coolify

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,229 @@
+name: PR preview
+
+# Builds the production image for a pull request, deploys it to Coolify as a
+# preview of the production application, then runs the end-to-end suite against
+# that deployment. The preview is destroyed when the pull request closes.
+#
+# Setup is documented in docs/pr-previews.md.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: 'thomasevano/musickeeper'
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build preview image
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      docker_tag: ${{ steps.tag.outputs.docker_tag }}
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - name: Compute image tag
+        id: tag
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR: ${{ github.event.pull_request.number }}
+        run: echo "docker_tag=pr-${PR}-${HEAD_SHA:0:7}" >> "$GITHUB_OUTPUT"
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push preview image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          # A preview only ever runs on the Coolify host, so one arch is enough.
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.docker_tag }}
+          cache-from: type=gha,scope=musickeeper-preview
+          cache-to: type=gha,mode=max,scope=musickeeper-preview
+
+  deploy:
+    name: Deploy preview
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    outputs:
+      preview_url: ${{ steps.url.outputs.preview_url }}
+    steps:
+      - name: Resolve preview URL
+        id: url
+        env:
+          TEMPLATE: ${{ vars.COOLIFY_PREVIEW_URL_TEMPLATE }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TEMPLATE}" ]; then
+            echo "::error::Repository variable COOLIFY_PREVIEW_URL_TEMPLATE is unset (expected e.g. https://pr-{{pr_id}}.example.com)."
+            exit 1
+          fi
+          echo "preview_url=${TEMPLATE//'{{pr_id}}'/${PR}}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger Coolify deployment
+        id: trigger
+        env:
+          COOLIFY_URL: ${{ secrets.COOLIFY_API_URL }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          APP_UUID: ${{ secrets.COOLIFY_APP_UUID }}
+          DOCKER_TAG: ${{ needs.build.outputs.docker_tag }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          code=$(curl -sS -o /tmp/deploy.json -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+            -H 'Accept: application/json' \
+            "${COOLIFY_URL%/}/api/v1/deploy?uuid=${APP_UUID}&pr=${PR}&docker_tag=${DOCKER_TAG}")
+          if [ "${code}" != '200' ]; then
+            echo "::error::Coolify rejected the deploy request (HTTP ${code}): $(cat /tmp/deploy.json)"
+            exit 1
+          fi
+          deployment_uuid=$(jq -r '.deployments[0].deployment_uuid // empty' /tmp/deploy.json)
+          if [ -z "${deployment_uuid}" ]; then
+            echo "::error::Coolify queued no deployment: $(cat /tmp/deploy.json)"
+            exit 1
+          fi
+          echo "deployment_uuid=${deployment_uuid}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the deployment to finish
+        timeout-minutes: 20
+        env:
+          COOLIFY_URL: ${{ secrets.COOLIFY_API_URL }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          DEPLOYMENT_UUID: ${{ steps.trigger.outputs.deployment_uuid }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 180); do
+            code=$(curl -sS -o /tmp/status.json -w '%{http_code}' \
+              -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+              -H 'Accept: application/json' \
+              "${COOLIFY_URL%/}/api/v1/deployments/${DEPLOYMENT_UUID}" || echo 000)
+            if [ "${code}" = '200' ]; then
+              status=$(jq -r 'if type == "array" then .[0].status else .status end' /tmp/status.json)
+              echo "deployment status: ${status}"
+              case "${status}" in
+                finished) exit 0 ;;
+                failed | cancelled-by-user)
+                  echo "::error::Coolify deployment ${status}. Logs: ${COOLIFY_URL%/}/deployment/${DEPLOYMENT_UUID}"
+                  exit 1
+                  ;;
+              esac
+            else
+              echo "status query returned HTTP ${code}"
+            fi
+            sleep 5
+          done
+          echo '::error::Timed out waiting for the Coolify deployment to finish.'
+          exit 1
+
+      - name: Wait for the preview to answer
+        timeout-minutes: 5
+        env:
+          PREVIEW_URL: ${{ steps.url.outputs.preview_url }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "${PREVIEW_URL%/}/" || echo 000)
+            if [ "${code}" = '200' ]; then
+              echo "${PREVIEW_URL} is serving HTTP 200"
+              exit 0
+            fi
+            echo "waiting for ${PREVIEW_URL} (HTTP ${code})"
+            sleep 5
+          done
+          echo "::error::${PREVIEW_URL} never answered with HTTP 200."
+          exit 1
+
+      - name: Comment the preview URL
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          PREVIEW_URL: ${{ steps.url.outputs.preview_url }}
+          DOCKER_TAG: ${{ needs.build.outputs.docker_tag }}
+        run: |
+          set -euo pipefail
+          marker='<!-- coolify-preview -->'
+          body="${marker}
+          ### Preview deployment
+
+          | | |
+          | --- | --- |
+          | URL | ${PREVIEW_URL} |
+          | Image | \`${REGISTRY}/${IMAGE_NAME}:${DOCKER_TAG}\` |
+          | Commit | ${{ github.event.pull_request.head.sha }} |
+
+          Same image and same Dockerfile as a release build."
+          comment_id=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+            --jq "[.[] | select(.body | startswith(\"${marker}\"))] | first | .id // empty")
+          if [ -n "${comment_id}" ]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${comment_id}" -f body="${body}"
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" -f body="${body}"
+          fi
+
+  e2e:
+    name: End-to-end against preview
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright browser
+        run: pnpm exec playwright install --with-deps chromium
+      - name: Run end-to-end tests
+        run: pnpm run test:e2e
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ needs.deploy.outputs.preview_url }}
+
+  destroy:
+    name: Destroy preview
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete the Coolify preview
+        env:
+          COOLIFY_URL: ${{ secrets.COOLIFY_API_URL }}
+          COOLIFY_TOKEN: ${{ secrets.COOLIFY_API_TOKEN }}
+          APP_UUID: ${{ secrets.COOLIFY_APP_UUID }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          code=$(curl -sS -o /tmp/destroy.json -w '%{http_code}' -X DELETE \
+            -H "Authorization: Bearer ${COOLIFY_TOKEN}" \
+            -H 'Accept: application/json' \
+            "${COOLIFY_URL%/}/api/v1/applications/${APP_UUID}/previews/${PR}")
+          case "${code}" in
+            200 | 204 | 404) echo "preview for PR ${PR} is gone (HTTP ${code})" ;;
+            *)
+              echo "::error::Failed to delete the preview (HTTP ${code}): $(cat /tmp/destroy.json)"
+              exit 1
+              ;;
+          esac

--- a/docs/pr-previews.md
+++ b/docs/pr-previews.md
@@ -1,0 +1,102 @@
+# Pull request previews on Coolify
+
+Every pull request gets a throwaway deployment of the **production image**, on the
+production host, behind its own HTTPS URL. The end-to-end suite then runs against
+that URL, so a green check means "this build boots and works in production", not
+"it compiled".
+
+Workflow: [`.github/workflows/pr-preview.yml`](../.github/workflows/pr-preview.yml).
+
+## How it works
+
+```mermaid
+graph LR
+  A[PR opened / pushed] --> B[Build Dockerfile, push ghcr pr-N-sha]
+  B --> C[POST /api/v1/deploy?uuid&pr=N&docker_tag=pr-N-sha]
+  C --> D[Poll /api/v1/deployments/uuid until finished]
+  D --> E[Wait for HTTPS 200 on the preview URL]
+  E --> F[Playwright against the preview]
+  G[PR closed] --> H[DELETE /applications/uuid/previews/N]
+```
+
+The image is the one the release pipeline ships: same `Dockerfile`, same
+`node ace build`, same runtime stage. Only the architecture differs — previews
+build `linux/amd64` only, releases also build `linux/arm64`.
+
+Coolify creates the preview record itself when `docker_tag` is passed together
+with `pr`, so nothing has to exist in Coolify before the first PR. That path is
+only available for applications whose build pack is **Docker Image**; see
+"Prerequisites".
+
+## Prerequisites
+
+1. **The Coolify application must use the `Docker Image` build pack**, pointing at
+   `ghcr.io/thomasevano/musickeeper`. If it is a Git-based application instead,
+   the API answers `docker_tag can only be used with Docker Image applications`;
+   in that case either switch the application to Docker Image, or drop the CI
+   build and use Coolify's native GitHub App preview deployments (which rebuild
+   on the server from the PR branch — slower, and not the released artifact).
+
+2. **The application needs an FQDN** (e.g. `https://musickeeper.app`). Coolify
+   derives the preview host from it.
+
+3. **Preview URL template**: in the application's `Preview Deployments` settings,
+   set the template to something deterministic, e.g. `pr-{{pr_id}}.{{domain}}`.
+   Do **not** use `{{random}}` — CI computes the URL from the same template and
+   would not be able to guess a random segment.
+
+4. **Wildcard DNS**: `*.musickeeper.app` → the Coolify host, so `pr-42.…`
+   resolves and Traefik can issue a certificate for it.
+
+5. **Environment variables**: mark every variable the preview needs (`APP_KEY`,
+   `PORT`, `LOG_LEVEL`, `NODE_ENV`, `SESSION_DRIVER`, `MB_APP_CONTACT_EMAIL`) as
+   _available for preview deployments_ in Coolify. The app has no database, so a
+   preview is fully disposable — nothing to seed, nothing to migrate.
+
+6. **Registry access**: the GHCR package must be pullable by the Coolify host —
+   public, or added as a registry credential in Coolify.
+
+## Repository configuration
+
+Secrets (`Settings → Secrets and variables → Actions → Secrets`):
+
+| Name                | Value                                                                               |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| `COOLIFY_API_URL`   | Base URL of the Coolify instance, e.g. `https://coolify.example.com` (no `/api/v1`) |
+| `COOLIFY_API_TOKEN` | API token from `Keys & Tokens → API tokens`, scoped to the team owning the app      |
+| `COOLIFY_APP_UUID`  | UUID of the production application (visible in its Coolify URL)                     |
+
+Variables (same page, `Variables` tab):
+
+| Name                           | Value                                                                                 |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| `COOLIFY_PREVIEW_URL_TEMPLATE` | `https://pr-{{pr_id}}.musickeeper.app` — must match the Coolify template, with scheme |
+
+## Behaviour
+
+- **Push to a PR** rebuilds and redeploys. The image tag embeds the head SHA
+  (`pr-42-a1b2c3d`), so Coolify always pulls a new artifact instead of a stale
+  cached tag.
+- **Concurrency** is per PR with `cancel-in-progress`, so rapid pushes do not
+  queue up deployments.
+- **Fork PRs are skipped** — they have no access to the secrets. Nothing is
+  deployed and no job fails.
+- **Closing or merging a PR** deletes the preview (containers, volumes, record).
+  The `pr-N-sha` images stay in GHCR; `GITHUB_TOKEN` cannot delete package
+  versions. Prune them manually or with a scheduled job using a PAT that has
+  `delete:packages`.
+
+## Failure modes worth recognising
+
+| Symptom                                                                                     | Cause                                                                                           |
+| ------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `Coolify rejected the deploy request (HTTP 400)` with `docker_tag requires pull_request_id` | `pr` was dropped from the query — check the workflow inputs                                     |
+| `docker_tag can only be used with Docker Image applications`                                | Prerequisite 1 is not met                                                                       |
+| Deployment reaches `finished` but the URL never answers 200                                 | Missing wildcard DNS, or template mismatch between Coolify and `COOLIFY_PREVIEW_URL_TEMPLATE`   |
+| Container restarts on boot                                                                  | A preview-scoped env var is missing; `src/infrastructure/env.ts` validates at startup and exits |
+
+## API reference used
+
+- `POST /api/v1/deploy?uuid=&pr=&docker_tag=` — queue a preview deployment
+- `GET /api/v1/deployments/{uuid}` — status: `queued`, `in_progress`, `finished`, `failed`, `cancelled-by-user`
+- `DELETE /api/v1/applications/{uuid}/previews/{pull_request_id}` — tear down

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from '@playwright/test'
 
+// When set, the suite runs against an already deployed target (a Coolify
+// preview in CI) instead of booting a local dev server.
+const externalBaseURL = process.env.PLAYWRIGHT_BASE_URL
+
 export default defineConfig({
   testDir: './tests/e2e',
   fullyParallel: true,
@@ -8,7 +12,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'list',
   use: {
-    baseURL: 'http://127.0.0.1:63136',
+    baseURL: externalBaseURL ?? 'http://127.0.0.1:63136',
     trace: 'on-first-retry',
   },
   projects: [
@@ -17,19 +21,21 @@ export default defineConfig({
       use: { browserName: 'chromium' },
     },
   ],
-  webServer: {
-    command: 'node ace serve --hmr',
-    url: 'http://127.0.0.1:63136',
-    reuseExistingServer: !process.env.CI,
-    timeout: 30000,
-    env: {
-      HOST: '127.0.0.1',
-      PORT: '63136',
-      NODE_ENV: 'development',
-      APP_KEY: 'applicationtestappkey',
-      SESSION_DRIVER: 'memory',
-      LOG_LEVEL: 'info',
-      MB_APP_CONTACT_EMAIL: 'test@test.com',
-    },
-  },
+  webServer: externalBaseURL
+    ? undefined
+    : {
+        command: 'node ace serve --hmr',
+        url: 'http://127.0.0.1:63136',
+        reuseExistingServer: !process.env.CI,
+        timeout: 30000,
+        env: {
+          HOST: '127.0.0.1',
+          PORT: '63136',
+          NODE_ENV: 'development',
+          APP_KEY: 'applicationtestappkey',
+          SESSION_DRIVER: 'memory',
+          LOG_LEVEL: 'info',
+          MB_APP_CONTACT_EMAIL: 'test@test.com',
+        },
+      },
 })


### PR DESCRIPTION
Every pull request gets a throwaway deployment of the **production image**, on the Coolify host, behind its own HTTPS URL. The end-to-end suite then runs against that URL, so a green check means "this build boots and works in production", not "it compiled".

```
PR push  -> build & push ghcr :pr-N-sha
         -> POST /api/v1/deploy?uuid&pr=N&docker_tag=pr-N-sha
         -> poll /api/v1/deployments/{uuid} until finished
         -> wait for HTTPS 200 on the preview URL
         -> Playwright against the preview
PR close -> DELETE /api/v1/applications/{uuid}/previews/N
```

## Why the API, not Coolify's native GitHub-App previews

Native previews rebuild on the Coolify host from the PR branch: slower, competing with production for CPU, and **not the artifact we ship** — `build.yml` already pushes the release image to GHCR. This route reuses the existing `Dockerfile` and buildx cache and hands Coolify that exact image.

Verified in Coolify source (`DeployController::upsertDockerImagePreview`): for a **Docker Image** application, `pr` + `docker_tag` makes Coolify create the preview record and its FQDN on the fly, so nothing has to exist in Coolify before the first PR. Git-based applications require a pre-existing preview instead — see the prerequisites in the doc.

The app is stateless (no database, data lives in IndexedDB) and only `VITE_APP_NAME` is baked at build time, with a fallback, so one image is URL-agnostic and every preview is fully disposable.

## Changes

| File | Change |
| --- | --- |
| `.github/workflows/pr-preview.yml` | new — build / deploy / e2e / destroy |
| `playwright.config.ts` | `PLAYWRIGHT_BASE_URL` targets a deployed URL and disables the local `webServer` |
| `docs/pr-previews.md` | setup, prerequisites, failure modes |

## Verification

- **Production image + full e2e**: built the `Dockerfile` from `git archive HEAD` (the same file set CI checks out), ran the container with production env, then `PLAYWRIGHT_BASE_URL=http://127.0.0.1:8080 playwright test` — **14/14 passed**, no local web server. That is exactly the CI path.
- **Coolify API logic**: every `run:` block was extracted and executed against a mock implementing the real contract. Happy path (`in_progress` → `in_progress` → `finished`) plus failure paths: `failed` status, HTTP 401, and a rejected `docker_tag` all fail the job with the API message.
- Workflow YAML parses, all shell blocks pass `bash -n`, URL-template substitution and the unset-variable guard behave, `tsc --noEmit` and Prettier are clean.

## Required before this does anything

Secrets `COOLIFY_API_URL`, `COOLIFY_API_TOKEN`, `COOLIFY_APP_UUID`, and variable `COOLIFY_PREVIEW_URL_TEMPLATE`. On the Coolify side: the application must use the **Docker Image** build pack, the preview template must be deterministic (`pr-{{pr_id}}.{{domain}}`, **no `{{random}}`**), wildcard DNS must point at the host, and the runtime env vars must be flagged for preview deployments. All of it is in `docs/pr-previews.md`.

## Notes

- Fork pull requests are skipped by design — they have no access to the secrets.
- `pr-N-sha` images accumulate in GHCR: `GITHUB_TOKEN` cannot delete package versions. Documented, not automated; pruning needs a PAT with `delete:packages`.
