### PR TITLE
feat(ui): make Listen Later mobile-first

### DIFF
--- a/inertia/components/ListenLaterListTable.svelte
+++ b/inertia/components/ListenLaterListTable.svelte
@@ -12,8 +12,7 @@
     getPaginationRowModel,
     getSortedRowModel,
   } from '@tanstack/table-core'
-  import { fly } from 'svelte/transition'
-  import { cubicOut, cubicIn } from 'svelte/easing'
+  import { rowIn, rowOut } from './data-table/data_table_row_transitions.js'
   import DataTableActions from './data-table/data-table-actions.svelte'
   import DataTableStatusBadge from './data-table/data-table-status-badge.svelte'
   import DataTableTypeBadge from './data-table/data-table-type-badge.svelte'
@@ -31,39 +30,6 @@
   } from '$lib/components/ui/data-table/index.js'
   import type { ListenLaterItem } from '../../src/domain/music_item'
 
-  /**
-   * Custom transition that collapses height on exit so the table reflows
-   * smoothly instead of leaving a blank gap.
-   *
-   * Enter: fade + slide down from -6px  (ease-out, 250ms)
-   * Exit:  fade + slide right + height collapse (ease-in, 200ms — slightly
-   *        faster than entrance per web-animation-design guidelines)
-   *
-   * Both transitions are disabled when the user prefers reduced motion.
-   */
-  function rowIn(node: Element) {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      return { duration: 0 }
-    }
-    return fly(node, { y: -6, opacity: 0, duration: 250, easing: cubicOut })
-  }
-
-  function rowOut(node: Element) {
-    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      return { duration: 0 }
-    }
-    const height = (node as HTMLElement).offsetHeight
-    return {
-      duration: 200,
-      easing: cubicIn,
-      css: (t: number) => `
-        opacity: ${t};
-        transform: translateX(${(1 - t) * 14}px);
-        height: ${t * height}px;
-        overflow: hidden;
-      `,
-    }
-  }
 
   let {
     items,
@@ -89,8 +55,16 @@
     { value: 'album', label: 'Albums' },
   ]
 
+  const mobileSortOptions = [
+    { value: 'none', label: 'None' },
+    { value: 'artists_asc', label: 'Artists (A–Z)' },
+    { value: 'added_desc', label: 'Added (newest)' },
+    { value: 'added_asc', label: 'Added (oldest)' },
+  ]
+
   let statusFilter = $state<string>('all')
   let typeFilter = $state<string>('all')
+  let mobileSort = $state<string>('none')
 
   const columns: ColumnDef<ListenLaterItem>[] = [
     {
@@ -277,6 +251,17 @@
     }
   }
 
+  function handleMobileSortChange(value: string) {
+    mobileSort = value
+    if (value === 'none') {
+      sorting = []
+      return
+    }
+
+    const [id, direction] = value.split('_')
+    sorting = [{ id, desc: direction === 'desc' }]
+  }
+
   const columnLabels: Record<string, string> = {
     cover: 'Cover',
     itemType: 'Type',
@@ -288,19 +273,23 @@
   }
 
   const statusFilterLabel = $derived(
-    statusFilterOptions.find((o) => o.value === statusFilter)?.label ?? 'All'
+    statusFilterOptions.find((option) => option.value === statusFilter)?.label ?? 'All'
   )
 
   const typeFilterLabel = $derived(
-    typeFilterOptions.find((o) => o.value === typeFilter)?.label ?? 'All'
+    typeFilterOptions.find((option) => option.value === typeFilter)?.label ?? 'All'
+  )
+
+  const mobileSortLabel = $derived(
+    mobileSortOptions.find((o) => o.value === mobileSort)?.label ?? 'None'
   )
 </script>
 
 <div class="w-full">
-  <div class="flex items-center gap-2 py-4">
+  <div class="flex flex-wrap items-center gap-2 py-4">
     <!-- Status filter -->
     <Select.Root type="single" value={statusFilter} onValueChange={handleStatusFilterChange}>
-      <Select.Trigger class="w-[160px]">
+      <Select.Trigger class="min-h-11 w-full sm:min-h-10 sm:w-[160px]">
         <span>Status: {statusFilterLabel}</span>
       </Select.Trigger>
       <Select.Content>
@@ -314,7 +303,7 @@
 
     <!-- Type filter -->
     <Select.Root type="single" value={typeFilter} onValueChange={handleTypeFilterChange}>
-      <Select.Trigger class="w-[150px]">
+      <Select.Trigger class="min-h-11 w-full sm:min-h-10 sm:w-[150px]">
         <span>Type: {typeFilterLabel}</span>
       </Select.Trigger>
       <Select.Content>
@@ -326,11 +315,27 @@
       </Select.Content>
     </Select.Root>
 
+    <!-- Mobile sort -->
+    <div class="w-full md:hidden">
+      <Select.Root type="single" value={mobileSort} onValueChange={handleMobileSortChange}>
+        <Select.Trigger class="w-full">
+          <span>Sort: {mobileSortLabel}</span>
+        </Select.Trigger>
+        <Select.Content>
+          <Select.Group>
+            {#each mobileSortOptions as option (option.value)}
+              <Select.Item value={option.value} label={option.label}>{option.label}</Select.Item>
+            {/each}
+          </Select.Group>
+        </Select.Content>
+      </Select.Root>
+    </div>
+
     <!-- Column visibility toggle -->
     <DropdownMenu.Root>
       <DropdownMenu.Trigger>
         {#snippet child({ props })}
-          <Button {...props} variant="outline" class="ml-auto">
+          <Button {...props} variant="outline" class="min-h-11 w-full sm:ml-auto sm:min-h-10 sm:w-auto">
             Columns <ChevronDownIcon class="ml-2 size-4" />
           </Button>
         {/snippet}
@@ -348,13 +353,23 @@
     </DropdownMenu.Root>
   </div>
 
-  <div class="overflow-x-auto rounded-md border">
+  <div class="hidden overflow-x-auto rounded-md border md:block">
     <Table.Root>
       <Table.Header>
         {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
           <Table.Row>
             {#each headerGroup.headers as header (header.id)}
-              <Table.Head>
+              <Table.Head
+                aria-sort={
+                  header.column.getCanSort()
+                    ? header.column.getIsSorted() === 'asc'
+                      ? 'ascending'
+                      : header.column.getIsSorted() === 'desc'
+                        ? 'descending'
+                        : 'none'
+                    : undefined
+                }
+              >
                 {#if !header.isPlaceholder}
                   <FlexRender
                     content={header.column.columnDef.header}
@@ -394,6 +409,50 @@
         {/each}
       </Table.Body>
     </Table.Root>
+  </div>
+
+  <div class="space-y-3 md:hidden">
+    {#each table.getRowModel().rows as row (row.original.id)}
+      <article
+        id={`mobile-item-${row.original.id}`}
+        class={[
+          'rounded-lg border p-4 shadow-sm',
+          highlightedItemId === row.original.id ? 'bg-warning/20' : '',
+        ].join(' ')}
+      >
+        <div class="flex items-start gap-3">
+          <CoverArt
+            src={row.original.coverArt}
+            alt={`Cover of ${row.original.title}`}
+            size="sm"
+            class="shrink-0"
+          />
+          <div class="min-w-0 flex-1">
+            <DataTableTitleCell
+              title={row.original.title}
+              albumName={row.original.itemType === 'track' ? (row.original.albumName ?? null) : null}
+            />
+            <p class="text-muted-foreground mt-1 truncate text-sm">
+              {row.original.artists?.join(', ') || 'Unknown artist'}
+            </p>
+          </div>
+          <DataTableActions
+            item={row.original}
+            {onDelete}
+            {onToggleListen}
+          />
+        </div>
+        <div class="mt-3 flex flex-wrap items-center gap-2">
+          <DataTableTypeBadge type={row.original.itemType} />
+          <DataTableStatusBadge hasBeenListened={row.original.hasBeenListened} />
+        </div>
+        <div class="mt-3">
+          <DataTableLinksCell item={row.original} />
+        </div>
+      </article>
+    {:else}
+      <div class="rounded-lg border p-6 text-center text-sm text-muted-foreground">No results.</div>
+    {/each}
   </div>
 
   <div class="flex items-center justify-end space-x-2 pt-4">

--- a/inertia/components/ListenLaterListTable.svelte
+++ b/inertia/components/ListenLaterListTable.svelte
@@ -30,7 +30,6 @@
   } from '$lib/components/ui/data-table/index.js'
   import type { ListenLaterItem } from '../../src/domain/music_item'
 
-
   let {
     items,
     onDelete,
@@ -55,10 +54,10 @@
     { value: 'album', label: 'Albums' },
   ]
 
-  type MobileSort = 'none' | 'artists_asc' | 'added_desc' | 'added_asc'
+  type MobileSort = 'artists_desc' | 'artists_asc' | 'added_desc' | 'added_asc'
 
   const mobileSortOptions: { value: MobileSort; label: string; sorting: SortingState }[] = [
-    { value: 'none', label: 'None', sorting: [] },
+    { value: 'artists_desc', label: 'Artists (Z–A)', sorting: [{ id: 'artists', desc: true }] },
     { value: 'artists_asc', label: 'Artists (A–Z)', sorting: [{ id: 'artists', desc: false }] },
     { value: 'added_desc', label: 'Added (newest)', sorting: [{ id: 'addedAt', desc: true }] },
     { value: 'added_asc', label: 'Added (oldest)', sorting: [{ id: 'addedAt', desc: false }] },
@@ -129,15 +128,25 @@
       accessorKey: 'addedAt',
       header: ({ column }) => renderComponent(DataTableSortHeader, { column, label: 'Added' }),
       sortingFn: (a, b) => {
-        const aDate = a.original.addedAt instanceof Date ? a.original.addedAt.getTime() : Number(a.original.addedAt)
-        const bDate = b.original.addedAt instanceof Date ? b.original.addedAt.getTime() : Number(b.original.addedAt)
+        const aDate =
+          a.original.addedAt instanceof Date
+            ? a.original.addedAt.getTime()
+            : Number(a.original.addedAt)
+        const bDate =
+          b.original.addedAt instanceof Date
+            ? b.original.addedAt.getTime()
+            : Number(b.original.addedAt)
         return aDate - bDate
       },
       cell: ({ row }) => {
         const d = row.original.addedAt
         if (!d) return '-'
         const date = d instanceof Date ? d : new Date(d)
-        return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+        return date.toLocaleDateString(undefined, {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric',
+        })
       },
     },
     {
@@ -153,7 +162,9 @@
         const d = row.original.releaseDate
         if (!d) return '-'
         const date = new Date(d)
-        return isNaN(date.getTime()) ? '-' : date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+        return isNaN(date.getTime())
+          ? '-'
+          : date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
       },
     },
     {
@@ -273,14 +284,13 @@
       (option) =>
         option.sorting.length === sorting.length &&
         option.sorting.every(
-          (entry, index) =>
-            entry.id === sorting[index]?.id && entry.desc === sorting[index]?.desc
+          (entry, index) => entry.id === sorting[index]?.id && entry.desc === sorting[index]?.desc
         )
     )
   )
 
   const mobileSort = $derived<MobileSort | 'custom'>(
-    sorting.length === 0 ? 'none' : (selectedMobileSortOption?.value ?? 'custom')
+    sorting.length === 0 ? 'added_asc' : (selectedMobileSortOption?.value ?? 'custom')
   )
 
   const statusFilterLabel = $derived(
@@ -292,7 +302,7 @@
   )
 
   const mobileSortLabel = $derived(
-    selectedMobileSortOption?.label ??
+    mobileSortOptions.find((option) => option.value === mobileSort)?.label ??
       sorting
         .map(
           (entry) =>
@@ -379,15 +389,13 @@
           <Table.Row>
             {#each headerGroup.headers as header (header.id)}
               <Table.Head
-                aria-sort={
-                  header.column.getCanSort()
-                    ? header.column.getIsSorted() === 'asc'
-                      ? 'ascending'
-                      : header.column.getIsSorted() === 'desc'
-                        ? 'descending'
-                        : 'none'
-                    : undefined
-                }
+                aria-sort={header.column.getCanSort()
+                  ? header.column.getIsSorted() === 'asc'
+                    ? 'ascending'
+                    : header.column.getIsSorted() === 'desc'
+                      ? 'descending'
+                      : 'none'
+                  : undefined}
               >
                 {#if !header.isPlaceholder}
                   <FlexRender
@@ -449,17 +457,15 @@
           <div class="min-w-0 flex-1 leading-tight text-pretty">
             <DataTableTitleCell
               title={row.original.title}
-              albumName={row.original.itemType === 'track' ? (row.original.albumName ?? null) : null}
+              albumName={row.original.itemType === 'track'
+                ? (row.original.albumName ?? null)
+                : null}
             />
             <p class="text-muted-foreground mt-1 truncate text-sm text-pretty">
               {row.original.artists?.join(', ') || 'Unknown artist'}
             </p>
           </div>
-          <DataTableActions
-            item={row.original}
-            {onDelete}
-            {onToggleListen}
-          />
+          <DataTableActions item={row.original} {onDelete} {onToggleListen} />
         </div>
         <div class="mt-3 flex flex-wrap items-center gap-2">
           <DataTableTypeBadge type={row.original.itemType} />

--- a/inertia/components/ListenLaterListTable.svelte
+++ b/inertia/components/ListenLaterListTable.svelte
@@ -55,16 +55,17 @@
     { value: 'album', label: 'Albums' },
   ]
 
-  const mobileSortOptions = [
-    { value: 'none', label: 'None' },
-    { value: 'artists_asc', label: 'Artists (A–Z)' },
-    { value: 'added_desc', label: 'Added (newest)' },
-    { value: 'added_asc', label: 'Added (oldest)' },
+  type MobileSort = 'none' | 'artists_asc' | 'added_desc' | 'added_asc'
+
+  const mobileSortOptions: { value: MobileSort; label: string; sorting: SortingState }[] = [
+    { value: 'none', label: 'None', sorting: [] },
+    { value: 'artists_asc', label: 'Artists (A–Z)', sorting: [{ id: 'artists', desc: false }] },
+    { value: 'added_desc', label: 'Added (newest)', sorting: [{ id: 'addedAt', desc: true }] },
+    { value: 'added_asc', label: 'Added (oldest)', sorting: [{ id: 'addedAt', desc: false }] },
   ]
 
   let statusFilter = $state<string>('all')
   let typeFilter = $state<string>('all')
-  let mobileSort = $state<string>('none')
 
   const columns: ColumnDef<ListenLaterItem>[] = [
     {
@@ -252,14 +253,9 @@
   }
 
   function handleMobileSortChange(value: string) {
-    mobileSort = value
-    if (value === 'none') {
-      sorting = []
-      return
-    }
-
-    const [id, direction] = value.split('_')
-    sorting = [{ id, desc: direction === 'desc' }]
+    const selectedOption = mobileSortOptions.find((option) => option.value === value)
+    if (!selectedOption) return
+    sorting = selectedOption.sorting
   }
 
   const columnLabels: Record<string, string> = {
@@ -272,6 +268,21 @@
     links: 'Links',
   }
 
+  const selectedMobileSortOption = $derived(
+    mobileSortOptions.find(
+      (option) =>
+        option.sorting.length === sorting.length &&
+        option.sorting.every(
+          (entry, index) =>
+            entry.id === sorting[index]?.id && entry.desc === sorting[index]?.desc
+        )
+    )
+  )
+
+  const mobileSort = $derived<MobileSort | 'custom'>(
+    sorting.length === 0 ? 'none' : (selectedMobileSortOption?.value ?? 'custom')
+  )
+
   const statusFilterLabel = $derived(
     statusFilterOptions.find((option) => option.value === statusFilter)?.label ?? 'All'
   )
@@ -281,7 +292,13 @@
   )
 
   const mobileSortLabel = $derived(
-    mobileSortOptions.find((o) => o.value === mobileSort)?.label ?? 'None'
+    selectedMobileSortOption?.label ??
+      sorting
+        .map(
+          (entry) =>
+            `${columnLabels[entry.id] ?? entry.id} (${entry.desc ? 'descending' : 'ascending'})`
+        )
+        .join(', ')
   )
 </script>
 

--- a/inertia/components/ListenLaterListTable.svelte
+++ b/inertia/components/ListenLaterListTable.svelte
@@ -349,25 +349,27 @@
     </div>
 
     <!-- Column visibility toggle -->
-    <DropdownMenu.Root>
-      <DropdownMenu.Trigger>
-        {#snippet child({ props })}
-          <Button {...props} variant="outline" class="min-h-11 w-full sm:ml-auto sm:min-h-10 sm:w-auto">
-            Columns <ChevronDownIcon class="ml-2 size-4" />
-          </Button>
-        {/snippet}
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content align="end">
-        {#each table.getAllColumns().filter((col) => col.getCanHide()) as column (column.id)}
-          <DropdownMenu.CheckboxItem
-            class="capitalize"
-            bind:checked={() => column.getIsVisible(), (v) => column.toggleVisibility(!!v)}
-          >
-            {columnLabels[column.id] ?? column.id}
-          </DropdownMenu.CheckboxItem>
-        {/each}
-      </DropdownMenu.Content>
-    </DropdownMenu.Root>
+    <div class="w-full md:ml-auto md:w-auto">
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          {#snippet child({ props })}
+            <Button {...props} variant="outline" class="w-full sm:ml-auto sm:w-auto">
+              Columns <ChevronDownIcon class="ml-2 size-4" />
+            </Button>
+          {/snippet}
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end">
+          {#each table.getAllColumns().filter((col) => col.getCanHide()) as column (column.id)}
+            <DropdownMenu.CheckboxItem
+              class="capitalize"
+              bind:checked={() => column.getIsVisible(), (v) => column.toggleVisibility(!!v)}
+            >
+              {columnLabels[column.id] ?? column.id}
+            </DropdownMenu.CheckboxItem>
+          {/each}
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </div>
   </div>
 
   <div class="hidden overflow-x-auto rounded-md border md:block">
@@ -433,7 +435,7 @@
       <article
         id={`mobile-item-${row.original.id}`}
         class={[
-          'rounded-lg border p-4 shadow-sm',
+          'rounded-xl border bg-card p-3 shadow-sm',
           highlightedItemId === row.original.id ? 'bg-warning/20' : '',
         ].join(' ')}
       >
@@ -444,12 +446,12 @@
             size="sm"
             class="shrink-0"
           />
-          <div class="min-w-0 flex-1">
+          <div class="min-w-0 flex-1 leading-tight text-pretty">
             <DataTableTitleCell
               title={row.original.title}
               albumName={row.original.itemType === 'track' ? (row.original.albumName ?? null) : null}
             />
-            <p class="text-muted-foreground mt-1 truncate text-sm">
+            <p class="text-muted-foreground mt-1 truncate text-sm text-pretty">
               {row.original.artists?.join(', ') || 'Unknown artist'}
             </p>
           </div>
@@ -463,9 +465,11 @@
           <DataTableTypeBadge type={row.original.itemType} />
           <DataTableStatusBadge hasBeenListened={row.original.hasBeenListened} />
         </div>
-        <div class="mt-3">
-          <DataTableLinksCell item={row.original} />
-        </div>
+        {#if row.original.externalLinks?.length}
+          <div class="mt-3 border-t pt-3">
+            <DataTableLinksCell item={row.original} />
+          </div>
+        {/if}
       </article>
     {:else}
       <div class="rounded-lg border p-6 text-center text-sm text-muted-foreground">No results.</div>

--- a/inertia/components/ListenLaterListTable.svelte
+++ b/inertia/components/ListenLaterListTable.svelte
@@ -348,12 +348,12 @@
       </Select.Root>
     </div>
 
-    <!-- Column visibility toggle -->
-    <div class="w-full md:ml-auto md:w-auto">
+    <!-- Column visibility toggle (desktop table only; mobile cards ignore column visibility) -->
+    <div class="hidden md:ml-auto md:block">
       <DropdownMenu.Root>
         <DropdownMenu.Trigger>
           {#snippet child({ props })}
-            <Button {...props} variant="outline" class="w-full sm:ml-auto sm:w-auto">
+            <Button {...props} variant="outline">
               Columns <ChevronDownIcon class="ml-2 size-4" />
             </Button>
           {/snippet}

--- a/inertia/components/ListenLaterListTable.svelte
+++ b/inertia/components/ListenLaterListTable.svelte
@@ -306,7 +306,7 @@
   <div class="flex flex-wrap items-center gap-2 py-4">
     <!-- Status filter -->
     <Select.Root type="single" value={statusFilter} onValueChange={handleStatusFilterChange}>
-      <Select.Trigger class="min-h-11 w-full sm:min-h-10 sm:w-[160px]">
+      <Select.Trigger class="w-full md:w-[160px]">
         <span>Status: {statusFilterLabel}</span>
       </Select.Trigger>
       <Select.Content>
@@ -320,7 +320,7 @@
 
     <!-- Type filter -->
     <Select.Root type="single" value={typeFilter} onValueChange={handleTypeFilterChange}>
-      <Select.Trigger class="min-h-11 w-full sm:min-h-10 sm:w-[150px]">
+      <Select.Trigger class="w-full md:w-[150px]">
         <span>Type: {typeFilterLabel}</span>
       </Select.Trigger>
       <Select.Content>

--- a/inertia/components/Navigation.svelte
+++ b/inertia/components/Navigation.svelte
@@ -19,6 +19,10 @@
     },
   ] as const
   let mobileNavOpen = $state(false)
+
+  $effect(() => {
+    if (!isMobile.current) mobileNavOpen = false
+  })
 </script>
 
 {#snippet navigationLink(
@@ -79,15 +83,15 @@
   <Sheet.Root bind:open={mobileNavOpen}>
     <Sheet.Trigger class="md:hidden">
       {#snippet child({ props })}
-        <Button {...props} variant="outline" size="icon" class="size-11" aria-label="Open navigation">
+        <Button {...props} variant="outline" size="icon" class="md:hidden" aria-label="Open navigation">
           <MenuIcon class="size-5" aria-hidden="true" />
         </Button>
       {/snippet}
     </Sheet.Trigger>
     <Sheet.Content side="right" class="w-[min(20rem,calc(100%-1rem))]">
-      <Sheet.Header>
-        <Sheet.Title>MusicKeeper</Sheet.Title>
-        <Sheet.Description>Navigate MusicKeeper.</Sheet.Description>
+      <Sheet.Header class="sr-only">
+        <Sheet.Title>Navigation</Sheet.Title>
+        <Sheet.Description>Site links and theme settings.</Sheet.Description>
       </Sheet.Header>
       <nav class="flex flex-col gap-2 px-2 pt-4" aria-label="Mobile navigation">
         {#each navigationLinks as link (link.href)}

--- a/inertia/components/Navigation.svelte
+++ b/inertia/components/Navigation.svelte
@@ -1,19 +1,53 @@
 <script lang="ts">
+  import MenuIcon from '@lucide/svelte/icons/menu'
   import { IsMobile } from '$lib/components/hooks/is_mobile.svelte.js'
   import * as NavigationMenu from '$lib/components/ui/navigation-menu/index.js'
   import { navigationMenuTriggerStyle } from '$lib/components/ui/navigation-menu/navigation-menu-trigger.svelte'
+  import * as Sheet from '$lib/components/ui/sheet/index.js'
+  import { Button } from '$lib/components/ui/button/index.js'
+  import { controlHeights } from '$lib/components/ui/control_heights.js'
   import { ModeWatcher } from 'mode-watcher'
   import ToggleTheme from './ToggleTheme.svelte'
 
   const isMobile = new IsMobile()
+  const navigationLinks = [
+    { href: '/#features', label: 'Features', external: false },
+    {
+      href: 'https://thomasevano.fr/en/tags/musickeeper/',
+      label: 'Blog',
+      external: true,
+    },
+  ] as const
+  let mobileNavOpen = $state(false)
 </script>
+
+{#snippet navigationLink(
+  link: (typeof navigationLinks)[number],
+  className: string,
+  onclick: (() => void) | undefined
+)}
+  <a
+    href={link.href}
+    class={className}
+    rel={link.external ? 'noopener noreferrer' : undefined}
+    target={link.external ? '_blank' : undefined}
+    {onclick}
+  >
+    {link.label}
+    {#if link.external}<span class="sr-only"> (opens in new tab)</span>{/if}
+  </a>
+{/snippet}
 
 <NavigationMenu.Root
   viewport={isMobile.current}
-  class="mx-auto w-full max-w-screen-2xl px-8 flex flex-0 py-5 justify-between items-center md:px-12 lg:px-16"
+  class="mx-auto flex w-full max-w-screen-2xl flex-0 items-center justify-between px-8 py-5 md:px-12 lg:px-16"
 >
   <ModeWatcher />
-  <a href="/" class="font-display font-bold flex items-center gap-2">
+  <a
+    href="/"
+    class={`flex items-center gap-2 font-display font-bold ${controlHeights.menuItem}`}
+    aria-label="MusicKeeper home"
+  >
     <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
       fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
       aria-hidden="true">
@@ -25,23 +59,48 @@
     </svg>
     MusicKeeper
   </a>
-  <NavigationMenu.List class="flex-wrap">
-    <NavigationMenu.Item>
-      <NavigationMenu.Link>
-        {#snippet child()}
-          <a href="/#features" class={navigationMenuTriggerStyle()}>Features</a>
-        {/snippet}
-      </NavigationMenu.Link>
-    </NavigationMenu.Item>
-    <NavigationMenu.Item>
-      <NavigationMenu.Link>
-        {#snippet child()}
-          <a href="https://thomasevano.fr/en/tags/musickeeper/" class={navigationMenuTriggerStyle()}
-            rel="noopener noreferrer" target="_blank">Blog<span class="sr-only"> (opens in new tab)</span></a
-          >
-        {/snippet}
-      </NavigationMenu.Link>
-    </NavigationMenu.Item>
+
+  <NavigationMenu.List class="hidden md:flex">
+    {#each navigationLinks as link (link.href)}
+      <NavigationMenu.Item>
+        <NavigationMenu.Link>
+          {#snippet child()}
+            {@render navigationLink(link, navigationMenuTriggerStyle(), undefined)}
+          {/snippet}
+        </NavigationMenu.Link>
+      </NavigationMenu.Item>
+    {/each}
   </NavigationMenu.List>
-  <ToggleTheme />
+
+  <div class="hidden md:block">
+    <ToggleTheme />
+  </div>
+
+  <Sheet.Root bind:open={mobileNavOpen}>
+    <Sheet.Trigger class="md:hidden">
+      {#snippet child({ props })}
+        <Button {...props} variant="outline" size="icon" class="size-11" aria-label="Open navigation">
+          <MenuIcon class="size-5" aria-hidden="true" />
+        </Button>
+      {/snippet}
+    </Sheet.Trigger>
+    <Sheet.Content side="right" class="w-[min(20rem,calc(100%-1rem))]">
+      <Sheet.Header>
+        <Sheet.Title>MusicKeeper</Sheet.Title>
+        <Sheet.Description>Navigate MusicKeeper.</Sheet.Description>
+      </Sheet.Header>
+      <nav class="flex flex-col gap-2 px-2 pt-4" aria-label="Mobile navigation">
+        {#each navigationLinks as link (link.href)}
+          {@render navigationLink(
+            link,
+            'flex min-h-11 items-center rounded-md px-3 py-2 text-sm font-medium hover:bg-muted',
+            () => (mobileNavOpen = false)
+          )}
+        {/each}
+        <div class="pt-2">
+          <ToggleTheme />
+        </div>
+      </nav>
+    </Sheet.Content>
+  </Sheet.Root>
 </NavigationMenu.Root>

--- a/inertia/components/data-table/data-table-actions.svelte
+++ b/inertia/components/data-table/data-table-actions.svelte
@@ -19,7 +19,7 @@
   <DropdownMenu.Root>
     <DropdownMenu.Trigger>
       {#snippet child({ props })}
-        <Button {...props} variant="ghost" size="icon" class="relative size-8 p-0">
+        <Button {...props} variant="ghost" size="icon" class="relative p-0">
           <span class="sr-only">Open menu</span>
           <EllipsisIcon />
         </Button>

--- a/inertia/components/data-table/data-table-links-cell.svelte
+++ b/inertia/components/data-table/data-table-links-cell.svelte
@@ -15,7 +15,7 @@
         href={l.url}
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex h-5 items-center gap-1 rounded-full bg-primary/10 px-1.5 text-[11px] font-medium text-primary ring-1 ring-primary/20 transition-colors hover:bg-primary/20"
+        class="inline-flex h-11 items-center gap-1 rounded-full bg-primary/10 px-2 text-[11px] font-medium text-primary ring-1 ring-primary/20 transition-colors hover:bg-primary/20 sm:h-5 sm:px-1.5"
       >
         <Music class="size-3 shrink-0" />
         {l.label}
@@ -29,7 +29,7 @@
         href={l.url}
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex h-5 items-center gap-1 rounded-full border border-emerald-300/50 bg-emerald-50 px-1.5 text-[11px] font-medium text-emerald-700 transition-colors hover:bg-emerald-100 dark:border-emerald-700/40 dark:bg-emerald-950/30 dark:text-emerald-400 dark:hover:bg-emerald-900/40"
+        class="inline-flex h-11 items-center gap-1 rounded-full border border-emerald-300/50 bg-emerald-50 px-2 text-[11px] font-medium text-emerald-700 transition-colors hover:bg-emerald-100 dark:border-emerald-700/40 dark:bg-emerald-950/30 dark:text-emerald-400 dark:hover:bg-emerald-900/40 sm:h-5 sm:px-1.5"
       >
         <ShoppingBag class="size-3 shrink-0" />
         {l.label}

--- a/inertia/components/data-table/data-table-links-cell.svelte
+++ b/inertia/components/data-table/data-table-links-cell.svelte
@@ -4,36 +4,41 @@
   import type { ListenLaterItem } from '../../../src/domain/music_item'
   let { item }: { item: ListenLaterItem } = $props()
   const links = $derived(item.externalLinks ?? [])
-  const stream = $derived(links.filter((l: any) => l.category === 'stream').sort((a: any, b: any) => a.label.localeCompare(b.label)))
-  const buy = $derived(links.filter((l: any) => l.category === 'buy').sort((a: any, b: any) => a.label.localeCompare(b.label)))
+  const stream = $derived(links.filter((link) => link.category === 'stream').sort((a, b) => a.label.localeCompare(b.label)))
+  const buy = $derived(links.filter((link) => link.category === 'buy').sort((a, b) => a.label.localeCompare(b.label)))
+  const linkPresentation = {
+    stream: {
+      classes:
+        'inline-flex min-h-11 items-center gap-1.5 rounded-md bg-primary/10 px-3 text-sm font-medium text-primary ring-1 ring-primary/20 transition-colors hover:bg-primary/20 sm:gap-1 sm:rounded-full sm:px-1.5 sm:text-[11px] md:min-h-5',
+      icon: Music,
+    },
+    buy: {
+      classes:
+        'inline-flex min-h-11 items-center gap-1.5 rounded-md border border-emerald-300/50 bg-emerald-50 px-3 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100 sm:gap-1 sm:rounded-full sm:px-1.5 sm:text-[11px] md:min-h-5 dark:border-emerald-700/40 dark:bg-emerald-950/30 dark:text-emerald-400 dark:hover:bg-emerald-900/40',
+      icon: ShoppingBag,
+    },
+  } as const
 </script>
 
 {#if links.length}
   <div class="flex flex-wrap items-center gap-1">
-    {#each stream as l (l.platform)}
-      <a
-        href={l.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="inline-flex h-11 items-center gap-1 rounded-full bg-primary/10 px-2 text-[11px] font-medium text-primary ring-1 ring-primary/20 transition-colors hover:bg-primary/20 sm:h-5 sm:px-1.5"
-      >
-        <Music class="size-3 shrink-0" />
-        {l.label}
-      </a>
-    {/each}
-    {#if stream.length && buy.length}
-      <span class="text-muted-foreground/40 mx-0.5">·</span>
-    {/if}
-    {#each buy as l (l.platform)}
-      <a
-        href={l.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="inline-flex h-11 items-center gap-1 rounded-full border border-emerald-300/50 bg-emerald-50 px-2 text-[11px] font-medium text-emerald-700 transition-colors hover:bg-emerald-100 dark:border-emerald-700/40 dark:bg-emerald-950/30 dark:text-emerald-400 dark:hover:bg-emerald-900/40 sm:h-5 sm:px-1.5"
-      >
-        <ShoppingBag class="size-3 shrink-0" />
-        {l.label}
-      </a>
+    {#each [stream, buy] as group, groupIndex}
+      {#if groupIndex === 1 && stream.length && buy.length}
+        <span class="text-muted-foreground/40 mx-0.5">·</span>
+      {/if}
+      {#each group as link (link.platform)}
+        {@const presentation = linkPresentation[link.category]}
+        {@const Icon = presentation.icon}
+        <a
+          href={link.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          class={presentation.classes}
+        >
+          <Icon class="size-3 shrink-0" />
+          {link.label}
+        </a>
+      {/each}
     {/each}
   </div>
 {/if}

--- a/inertia/components/data-table/data-table-sort-header.svelte
+++ b/inertia/components/data-table/data-table-sort-header.svelte
@@ -19,6 +19,7 @@
 <Button
   variant="ghost"
   class="cursor-pointer px-0 hover:bg-transparent"
+  aria-label={`${label}, ${sorted === 'asc' ? 'sorted ascending' : sorted === 'desc' ? 'sorted descending' : 'not sorted'}`}
   onclick={() => column.toggleSorting(sorted === 'asc')}
 >
   {label}

--- a/inertia/components/data-table/data-table-title-cell.svelte
+++ b/inertia/components/data-table/data-table-title-cell.svelte
@@ -2,9 +2,9 @@
   let { title, albumName }: { title: string; albumName: string | null } = $props()
 </script>
 
-<div class="flex flex-col">
-  <span class="font-medium">{title}</span>
+<div class="flex min-w-0 flex-col">
+  <span class="font-medium [overflow-wrap:anywhere]">{title}</span>
   {#if albumName}
-    <span class="text-muted-foreground text-xs">{albumName}</span>
+    <span class="text-muted-foreground text-xs [overflow-wrap:anywhere]">{albumName}</span>
   {/if}
 </div>

--- a/inertia/components/data-table/data_table_row_transitions.ts
+++ b/inertia/components/data-table/data_table_row_transitions.ts
@@ -1,0 +1,17 @@
+import { cubicOut } from 'svelte/easing'
+import { fly, type TransitionConfig } from 'svelte/transition'
+
+/** Keep table row feedback on compositor-friendly properties. */
+export function rowIn(node: Element): TransitionConfig {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return { duration: 0 }
+  return fly(node, { y: -6, opacity: 0, duration: 180, easing: cubicOut })
+}
+
+export function rowOut(_node: Element): TransitionConfig {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return { duration: 0 }
+  return {
+    duration: 160,
+    easing: cubicOut,
+    css: (t) => `opacity: ${t}; transform: translateX(${(1 - t) * 14}px);`,
+  }
+}

--- a/inertia/lib/components/ui/button/button.svelte
+++ b/inertia/lib/components/ui/button/button.svelte
@@ -2,6 +2,7 @@
 	import type { WithElementRef } from "bits-ui";
 	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements";
 	import { type VariantProps, tv } from "tailwind-variants";
+	import { controlHeights } from "../control_heights.js";
 
 	export const buttonVariants = tv({
 		base: "ring-offset-background focus-visible:ring-ring inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -16,10 +17,10 @@
 				link: "text-primary underline-offset-4 hover:underline",
 			},
 			size: {
-				default: "h-10 px-4 py-2",
-				sm: "h-9 rounded-md px-3",
+				default: `${controlHeights.default} px-4 py-2`,
+				sm: `${controlHeights.smallButton} rounded-md px-3`,
 				lg: "h-11 rounded-md px-8",
-				icon: "h-10 w-10",
+				icon: controlHeights.iconButton,
 			},
 		},
 		defaultVariants: {

--- a/inertia/lib/components/ui/control_heights.ts
+++ b/inertia/lib/components/ui/control_heights.ts
@@ -1,0 +1,8 @@
+export const controlHeights = {
+  default: 'h-11 md:h-10',
+  smallButton: 'h-11 md:h-9',
+  iconButton: 'size-11 md:size-10',
+  select:
+    'data-[size=default]:h-11 data-[size=sm]:h-11 md:data-[size=default]:h-9 md:data-[size=sm]:h-8',
+  menuItem: 'min-h-11 md:min-h-0',
+} as const

--- a/inertia/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
+++ b/inertia/lib/components/ui/dropdown-menu/dropdown-menu-checkbox-item.svelte
@@ -3,6 +3,7 @@
   import Check from '@lucide/svelte/icons/check'
   import Minus from '@lucide/svelte/icons/minus'
   import { cn } from '$lib/utils.js'
+  import { controlHeights } from '../control_heights.js'
   import type { Snippet } from 'svelte'
 
   let {
@@ -23,6 +24,7 @@
   bind:indeterminate
   class={cn(
     'data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50',
+    controlHeights.menuItem,
     className
   )}
   {...restProps}

--- a/inertia/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/inertia/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { cn } from "$lib/utils.js";
 	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
+	import { controlHeights } from "../control_heights.js";
 
 	let {
 		ref = $bindable(null),
@@ -16,6 +17,7 @@
 	bind:ref
 	class={cn(
 		"data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+		controlHeights.menuItem,
 		inset && "pl-8",
 		className
 	)}

--- a/inertia/lib/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
+++ b/inertia/lib/components/ui/dropdown-menu/dropdown-menu-radio-item.svelte
@@ -2,6 +2,7 @@
   import { DropdownMenu as DropdownMenuPrimitive, type WithoutChild } from 'bits-ui'
   import Circle from '@lucide/svelte/icons/circle'
   import { cn } from '$lib/utils.js'
+  import { controlHeights } from '../control_heights.js'
 
   let {
     ref = $bindable(null),
@@ -15,6 +16,7 @@
   bind:ref
   class={cn(
     'data-highlighted:bg-accent data-highlighted:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden data-disabled:pointer-events-none data-disabled:opacity-50',
+    controlHeights.menuItem,
     className
   )}
   {...restProps}

--- a/inertia/lib/components/ui/input/input.svelte
+++ b/inertia/lib/components/ui/input/input.svelte
@@ -2,6 +2,7 @@
 	import type { HTMLInputAttributes, HTMLInputTypeAttribute } from "svelte/elements";
 	import type { WithElementRef } from "bits-ui";
 	import { cn } from "$lib/utils.js";
+	import { controlHeights } from "../control_heights.js";
 
 	type InputType = Exclude<HTMLInputTypeAttribute, "file">;
 
@@ -24,7 +25,8 @@
 	<input
 		bind:this={ref}
 		class={cn(
-			"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+			"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+			controlHeights.default,
 			className
 		)}
 		type="file"
@@ -36,7 +38,8 @@
 	<input
 		bind:this={ref}
 		class={cn(
-			"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+			"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+			controlHeights.default,
 			className
 		)}
 		{type}

--- a/inertia/lib/components/ui/select/select-item.svelte
+++ b/inertia/lib/components/ui/select/select-item.svelte
@@ -2,6 +2,7 @@
 	import CheckIcon from "@lucide/svelte/icons/check";
 	import { Select as SelectPrimitive } from "bits-ui";
 	import { cn, type WithoutChild } from "$lib/utils.js";
+	import { controlHeights } from "../control_heights.js";
 
 	let {
 		ref = $bindable(null),
@@ -19,6 +20,7 @@
 	data-slot="select-item"
 	class={cn(
 		"data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground outline-hidden *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-2 pr-8 text-sm data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		controlHeights.menuItem,
 		className
 	)}
 	{...restProps}

--- a/inertia/lib/components/ui/select/select-trigger.svelte
+++ b/inertia/lib/components/ui/select/select-trigger.svelte
@@ -2,6 +2,7 @@
 	import { Select as SelectPrimitive } from "bits-ui";
 	import ChevronDownIcon from "@lucide/svelte/icons/chevron-down";
 	import { cn, type WithoutChild } from "$lib/utils.js";
+	import { controlHeights } from "../control_heights.js";
 
 	let {
 		ref = $bindable(null),
@@ -19,7 +20,8 @@
 	data-slot="select-trigger"
 	data-size={size}
 	class={cn(
-		"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 shadow-xs flex w-fit select-none items-center justify-between gap-2 whitespace-nowrap rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 shadow-xs flex w-fit select-none items-center justify-between gap-2 whitespace-nowrap rounded-md border bg-transparent px-3 py-2 text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		controlHeights.select,
 		className
 	)}
 	{...restProps}

--- a/inertia/lib/components/ui/sheet/sheet-content.svelte
+++ b/inertia/lib/components/ui/sheet/sheet-content.svelte
@@ -1,13 +1,13 @@
 <script lang="ts" module>
 	import { tv, type VariantProps } from "tailwind-variants";
 	export const sheetVariants = tv({
-		base: "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 gap-4 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+		base: "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 gap-4 p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 motion-reduce:data-[state=closed]:fade-out-0 motion-reduce:data-[state=open]:fade-in-0",
 		variants: {
 			side: {
-				top: "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 border-b",
-				bottom: "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 border-t",
-				left: "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
-				right: "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+				top: "motion-safe:data-[state=closed]:slide-out-to-top motion-safe:data-[state=open]:slide-in-from-top inset-x-0 top-0 border-b",
+				bottom: "motion-safe:data-[state=closed]:slide-out-to-bottom motion-safe:data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 border-t",
+				left: "motion-safe:data-[state=closed]:slide-out-to-left motion-safe:data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+				right: "motion-safe:data-[state=closed]:slide-out-to-right motion-safe:data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
 			},
 		},
 		defaultVariants: {
@@ -24,6 +24,7 @@
 	import type { Snippet } from "svelte";
 	import SheetOverlay from "./sheet-overlay.svelte";
 	import { cn } from "$lib/utils.js";
+	import { controlHeights } from "../control_heights.js";
 
 	let {
 		ref = $bindable(null),
@@ -41,13 +42,45 @@
 
 <SheetPrimitive.Portal {...portalProps}>
 	<SheetOverlay />
-	<SheetPrimitive.Content bind:ref class={cn(sheetVariants({ side }), className)} {...restProps}>
+	<SheetPrimitive.Content
+		bind:ref
+		data-slot="sheet-content"
+		class={cn(sheetVariants({ side }), className)}
+		{...restProps}
+	>
 		{@render children?.()}
 		<SheetPrimitive.Close
-			class="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none"
+			class={cn(
+				"ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute right-4 top-4 flex items-center justify-center rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none",
+				controlHeights.iconButton,
+			)}
 		>
 			<X class="size-4" />
 			<span class="sr-only">Close</span>
 		</SheetPrimitive.Close>
 	</SheetPrimitive.Content>
 </SheetPrimitive.Portal>
+
+<style>
+	@keyframes sheet-fade-in {
+		from {
+			opacity: 0;
+		}
+	}
+
+	@keyframes sheet-fade-out {
+		to {
+			opacity: 0;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		:global([data-slot="sheet-content"][data-state="open"]) {
+			animation-name: sheet-fade-in !important;
+		}
+
+		:global([data-slot="sheet-content"][data-state="closed"]) {
+			animation-name: sheet-fade-out !important;
+		}
+	}
+</style>

--- a/inertia/pages/listen-later.svelte
+++ b/inertia/pages/listen-later.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import * as Alert from '$lib/components/ui/alert/index.js'
   import * as Dialog from '$lib/components/ui/dialog/index.js'
+  import { controlHeights } from '$lib/components/ui/control_heights.js'
   import * as Select from '$lib/components/ui/select/index.js'
   import { Separator } from '$lib/components/ui/separator/index.js'
   import { Link2, Search, WifiOff } from '@lucide/svelte'
@@ -60,6 +61,10 @@
 
   const debouncedSearch = new Debounced(() => searchTerm, 300)
   const debouncedArtist = new Debounced(() => artistName, 300)
+  const searchInputClasses = [
+    'placeholder:text-muted-foreground flex w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50',
+    controlHeights.default,
+  ].join(' ')
 
   const hasSearchTerm = $derived(debouncedSearch.current.trim().length >= 3)
   const hasArtist = $derived(debouncedArtist.current.trim().length >= 3)
@@ -506,7 +511,7 @@
 </script>
 
 <LibraryLayout data={listenLaterItems}>
-  <div class="mx-auto w-full max-w-screen-2xl px-8 py-6 md:px-12 lg:px-16">
+  <div class="mx-auto w-full max-w-screen-2xl px-4 py-6 md:px-12 lg:px-16">
     {#if isOffline}
       <Alert.Root variant="info" class="mb-4">
         <WifiOff />
@@ -531,7 +536,7 @@
     <!-- Paste Link Section -->
     <div class="mb-6">
       <h3 class="text-lg font-medium mb-2">Add from Link</h3>
-      <div class="flex gap-2">
+      <div class="flex flex-col gap-2 sm:flex-row">
         <label for="link-url" class="sr-only">Music link URL</label>
         <Input
           id="link-url"
@@ -543,7 +548,11 @@
           aria-describedby={linkError ? 'link-url-error' : undefined}
           aria-invalid={linkError ? 'true' : undefined}
         />
-        <Button onclick={handlePasteLink} disabled={isProcessingLink || !linkUrl.trim()}>
+        <Button
+          class="w-full sm:w-auto"
+          onclick={handlePasteLink}
+          disabled={isProcessingLink || !linkUrl.trim()}
+        >
           <Link2 class="mr-2 h-4 w-4" aria-hidden="true" />
           {isProcessingLink ? 'Processing...' : 'Add'}
         </Button>
@@ -558,7 +567,7 @@
     <div class="mb-4 flex items-center gap-4" class:opacity-50={isOffline}>
       <label for="search-type" class="text-sm font-medium">Type:</label>
       <Select.Root type="single" bind:value={searchType} disabled={isOffline}>
-        <Select.Trigger id="search-type" class="w-[180px]">{triggerContent}</Select.Trigger>
+        <Select.Trigger id="search-type" class="w-full sm:w-[180px]">{triggerContent}</Select.Trigger>
 
         <Select.Content>
           <Select.Group>
@@ -575,8 +584,8 @@
     </div>
 
     <div class="rounded-lg border shadow-md mb-4" class:opacity-50={isOffline}>
-      <div class="flex gap-2 w-full border-b">
-        <div class="flex flex-1 items-center gap-2 ps-3 pe-8 h-9">
+      <div class="flex w-full flex-col gap-0 border-b sm:flex-row">
+        <div class="flex min-w-0 flex-1 items-center gap-2 p-3 sm:h-12 sm:py-1.5">
           <Search class="size-4 shrink-0 opacity-50" aria-hidden="true" />
           <label for="search-title" class="sr-only">Song or album title</label>
           <input
@@ -590,18 +599,18 @@
             aria-controls="search-results-list"
             aria-autocomplete="list"
             onkeydown={handleInputKeydown}
-            class="placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            class={searchInputClasses}
           />
         </div>
 
-        <div class="flex flex-1 items-center gap-2 ps-3 pe-3 h-9 border-l">
+        <div class="flex min-w-0 flex-1 items-center gap-2 border-t p-3 sm:h-12 sm:border-l sm:border-t-0 sm:py-1.5">
           <label for="search-artist" class="sr-only">Artist name</label>
           <input
             id="search-artist"
             bind:value={artistName}
             placeholder={isOffline ? 'Search disabled while offline' : 'Artist name (optional)...'}
             disabled={isOffline}
-            class="placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            class={searchInputClasses}
           />
         </div>
       </div>

--- a/inertia/pages/listen-later.svelte
+++ b/inertia/pages/listen-later.svelte
@@ -564,7 +564,7 @@
 
     <Separator class="my-4" />
 
-    <div class="mb-4 flex items-center gap-4" class:opacity-50={isOffline}>
+    <div class="mb-2 flex items-center gap-4" class:opacity-50={isOffline}>
       <label for="search-type" class="text-sm font-medium">Type:</label>
       <Select.Root type="single" bind:value={searchType} disabled={isOffline}>
         <Select.Trigger id="search-type" class="w-full sm:w-[180px]">{triggerContent}</Select.Trigger>
@@ -583,7 +583,7 @@
       </Select.Root>
     </div>
 
-    <div class="rounded-lg border shadow-md mb-4" class:opacity-50={isOffline}>
+    <div class="rounded-lg border shadow-md" class:opacity-50={isOffline}>
       <div class="flex w-full flex-col gap-0 border-b sm:flex-row">
         <div class="flex min-w-0 flex-1 items-center gap-2 p-3 sm:h-12 sm:py-1.5">
           <Search class="size-4 shrink-0 opacity-50" aria-hidden="true" />
@@ -647,6 +647,9 @@
         </div>
       {/if}
     </div>
+
+    <Separator class="my-6" />
+
     <div>
       {#if listenLaterItems.length > 0}
         <ListenLaterListTable

--- a/tests/e2e/listen_later.spec.ts
+++ b/tests/e2e/listen_later.spec.ts
@@ -552,35 +552,96 @@ test.describe('artist-only search', () => {
 })
 
 test.describe('table filters', () => {
-  test('filters rendered rows', async ({ page }) => {
+  test('combines type and listened-status filters', async ({ page }) => {
     await page.goto('/library/listen-later')
     await seedListenLaterItems(page, [
-      {
-        id: 'album-item',
-        title: 'Album result',
+      listenLaterSeed({
+        id: 'album-not-listened',
+        title: 'Unheard album',
         releaseDate: '2024-01-01',
         artists: ['Album Artist'],
-        itemType: 'album',
-        hasBeenListened: false,
-        addedAt: 1,
-      },
-      {
-        id: 'track-item',
-        title: 'Track result',
+      }),
+      listenLaterSeed({
+        id: 'album-listened',
+        title: 'Heard album',
         releaseDate: '2024-01-02',
+        artists: ['Album Artist'],
+        hasBeenListened: true,
+        addedAt: 2,
+      }),
+      listenLaterSeed({
+        id: 'track-not-listened',
+        title: 'Unheard track',
+        releaseDate: '2024-01-03',
         artists: ['Track Artist'],
         itemType: 'track',
-        hasBeenListened: false,
-        addedAt: 2,
-      },
+        addedAt: 3,
+      }),
     ])
 
     await page.getByRole('button', { name: 'Type: All', exact: true }).click()
     await page.getByRole('option', { name: 'Albums', exact: true }).click()
+    await page.getByRole('button', { name: 'Status: All', exact: true }).click()
+    await page.getByRole('option', { name: 'Not listened', exact: true }).click()
 
     await expect(page.getByText('1 item(s)')).toBeVisible()
-    await expect(page.getByRole('row').filter({ hasText: 'Album result' })).toBeVisible()
-    await expect(page.getByRole('row').filter({ hasText: 'Track result' })).not.toBeVisible()
+    await expect(page.locator('#item-album-not-listened')).toBeVisible()
+    await expect(page.locator('#item-album-listened')).not.toBeVisible()
+    await expect(page.locator('#item-track-not-listened')).not.toBeVisible()
+  })
+})
+
+test.describe('desktop sorting', () => {
+  test.use({ viewport: { width: 1280, height: 800 } })
+
+  test('exposes sort direction to assistive technology', async ({ page }) => {
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      listenLaterSeed({ id: 'sort-zebra', title: 'Zebra', artists: ['Zebra Artist'] }),
+      listenLaterSeed({ id: 'sort-apple', title: 'Apple', artists: ['Apple Artist'] }),
+    ])
+
+    const artistsButton = page.getByRole('button', { name: 'Artists, not sorted', exact: true })
+    const artistsHeader = page.locator('th').filter({ has: artistsButton })
+    await expect(artistsHeader).toHaveAttribute('aria-sort', 'none')
+
+    await artistsButton.click()
+    const ascendingButton = page.getByRole('button', {
+      name: 'Artists, sorted ascending',
+      exact: true,
+    })
+    await expect(page.locator('th').filter({ has: ascendingButton })).toHaveAttribute(
+      'aria-sort',
+      'ascending'
+    )
+    await expect(ascendingButton).toBeVisible()
+
+    await page.setViewportSize({ width: 320, height: 568 })
+    await expect(
+      page.getByRole('button', { name: 'Sort: Artists (A–Z)', exact: true })
+    ).toBeVisible()
+    await page.setViewportSize({ width: 1280, height: 800 })
+
+    await ascendingButton.click()
+    const descendingButton = page.getByRole('button', {
+      name: 'Artists, sorted descending',
+      exact: true,
+    })
+    await expect(page.locator('th').filter({ has: descendingButton })).toHaveAttribute(
+      'aria-sort',
+      'descending'
+    )
+    await expect(descendingButton).toBeVisible()
+
+    await page.setViewportSize({ width: 320, height: 568 })
+    const customSort = page.getByRole('button', {
+      name: 'Sort: Artists (descending)',
+      exact: true,
+    })
+    await expect(customSort).toBeVisible()
+    await customSort.click()
+    await page.getByRole('option', { name: 'None', exact: true }).click()
+    await expect(page.getByRole('button', { name: 'Sort: None', exact: true })).toBeVisible()
   })
 })
 
@@ -688,9 +749,16 @@ test.describe('mobile breakpoint controls', () => {
 test.describe('mobile navigation', () => {
   test.use({ viewport: { width: 320, height: 568 } })
 
-  test('provides compact navigation on narrow screens', async ({ page }) => {
+  test('opens the compact navigation sheet', async ({ page }) => {
     await page.goto('/')
-    await expect(page.getByRole('button', { name: 'Open navigation' })).toBeVisible()
+    await page.getByRole('button', { name: 'Open navigation' }).click()
+
+    const navigation = page.getByRole('navigation', { name: 'Mobile navigation' })
+    await expect(navigation).toBeVisible()
+    await expect(navigation.getByRole('link', { name: 'Features' })).toBeVisible()
+    await navigation.getByRole('link', { name: 'Features' }).click()
+    await expect(page).toHaveURL(/\/#features$/)
+    await expect(navigation).not.toBeVisible()
   })
 
   test('opens a Deezer album from a mobile card', async ({ page }) => {
@@ -763,25 +831,48 @@ test.describe('mobile navigation', () => {
     await expect(mobileCard).not.toBeVisible()
   })
 
-  test('provides mobile sorting for saved items', async ({ page }) => {
+  test('sorts saved items by artist and added date', async ({ page }) => {
     await page.goto('/library/listen-later')
     await seedListenLaterItems(page, [
-      {
-        id: 'mobile-sort-item',
-        title: 'Mobile sort item',
+      listenLaterSeed({
+        id: 'old-zebra',
+        title: 'Old Zebra album',
         releaseDate: '2024-01-01',
-        artists: ['Mobile Artist'],
-        itemType: 'album',
-        hasBeenListened: false,
-        addedAt: 1,
-      },
+        artists: ['Zebra Artist'],
+        addedAt: 2,
+      }),
+      listenLaterSeed({
+        id: 'new-apple',
+        title: 'New Apple album',
+        releaseDate: '2024-01-02',
+        artists: ['Apple Artist'],
+      }),
+      listenLaterSeed({
+        id: 'middle-mango',
+        title: 'Middle Mango album',
+        releaseDate: '2024-01-03',
+        artists: ['Mango Artist'],
+        addedAt: 3,
+      }),
     ])
+    const mobileItems = page.locator('article[id^="mobile-item-"]')
 
-    await expect(page.getByRole('button', { name: 'Sort: None', exact: true })).toBeVisible()
     await page.getByRole('button', { name: 'Sort: None', exact: true }).click()
     await page.getByRole('option', { name: 'Artists (A–Z)', exact: true }).click()
-    await expect(
-      page.getByRole('button', { name: 'Sort: Artists (A–Z)', exact: true })
-    ).toBeVisible()
+    await expect
+      .poll(() => mobileItems.evaluateAll((items) => items.map((item) => item.id)))
+      .toEqual(['mobile-item-new-apple', 'mobile-item-middle-mango', 'mobile-item-old-zebra'])
+
+    await page.getByRole('button', { name: 'Sort: Artists (A–Z)', exact: true }).click()
+    await page.getByRole('option', { name: 'Added (newest)', exact: true }).click()
+    await expect
+      .poll(() => mobileItems.evaluateAll((items) => items.map((item) => item.id)))
+      .toEqual(['mobile-item-middle-mango', 'mobile-item-old-zebra', 'mobile-item-new-apple'])
+
+    await page.getByRole('button', { name: 'Sort: Added (newest)', exact: true }).click()
+    await page.getByRole('option', { name: 'Added (oldest)', exact: true }).click()
+    await expect
+      .poll(() => mobileItems.evaluateAll((items) => items.map((item) => item.id)))
+      .toEqual(['mobile-item-new-apple', 'mobile-item-old-zebra', 'mobile-item-middle-mango'])
   })
 })

--- a/tests/e2e/listen_later.spec.ts
+++ b/tests/e2e/listen_later.spec.ts
@@ -642,7 +642,11 @@ test.describe('desktop sorting', () => {
     )
     await expect(descendingButton).toBeVisible()
 
+    const columnChooser = page.getByRole('button', { name: 'Columns', exact: true })
+    await expect(columnChooser).toBeVisible()
+
     await page.setViewportSize({ width: 320, height: 568 })
+    await expect(columnChooser).not.toBeVisible()
     const customSort = page.getByRole('button', {
       name: 'Sort: Artists (descending)',
       exact: true,
@@ -725,7 +729,6 @@ test.describe('mobile breakpoint controls', () => {
       page.getByRole('button', { name: 'Status: All', exact: true }),
       page.getByRole('button', { name: 'Type: All', exact: true }),
       page.getByRole('button', { name: 'Sort: None', exact: true }),
-      page.getByRole('button', { name: 'Columns', exact: true }),
       mobileCard.getByRole('button', { name: 'Open menu' }),
       mobileCard.getByRole('link', { name: 'Deezer' }),
       page.getByRole('button', { name: 'Previous' }),
@@ -749,10 +752,6 @@ test.describe('mobile breakpoint controls', () => {
       )
       await page.keyboard.press('Escape')
     }
-
-    await page.getByRole('button', { name: 'Columns', exact: true }).click()
-    await expectAllMinTouchTargets(page.getByRole('menuitemcheckbox'))
-    await page.keyboard.press('Escape')
 
     await mobileCard.getByRole('button', { name: 'Open menu' }).click()
     await expectAllMinTouchTargets(page.getByRole('menuitem'))
@@ -854,7 +853,6 @@ test.describe('mobile navigation', () => {
       }),
     ])
 
-    await expect(page.getByRole('button', { name: 'Columns', exact: true })).toBeVisible()
     const mobileCard = page.locator('#mobile-item-column-chooser-item')
     const platformLink = mobileCard.getByRole('link', { name: 'Spotify' })
 

--- a/tests/e2e/listen_later.spec.ts
+++ b/tests/e2e/listen_later.spec.ts
@@ -79,6 +79,15 @@ async function expectAllMinTouchTargets(locator: Locator) {
   }
 }
 
+async function expectStacked(first: Locator, second: Locator) {
+  await expect
+    .poll(async () => {
+      const [firstBox, secondBox] = await Promise.all([first.boundingBox(), second.boundingBox()])
+      return !!firstBox && !!secondBox && secondBox.y >= firstBox.y + firstBox.height
+    })
+    .toBe(true)
+}
+
 async function addSpotifyItem(page: Page) {
   await page.getByPlaceholder('Paste a link from Spotify').fill(SPOTIFY_URL)
   await addLinkButton(page).click()
@@ -645,6 +654,20 @@ test.describe('desktop sorting', () => {
   })
 })
 
+test.describe('desktop navigation', () => {
+  test.use({ viewport: { width: 1280, height: 800 } })
+
+  test('hides the compact navigation trigger', async ({ page }) => {
+    await page.goto('/')
+
+    // The trigger's `md:hidden` is forwarded through a bits-ui child snippet, so
+    // a stray `class` on the Button silently drops it and ships the burger on
+    // desktop next to the inline links.
+    await expect(page.getByRole('button', { name: 'Open navigation' })).not.toBeVisible()
+    await expect(page.getByRole('link', { name: 'Features' })).toBeVisible()
+  })
+})
+
 test.describe('reduced motion', () => {
   test.use({ viewport: { width: 320, height: 568 } })
 
@@ -762,7 +785,18 @@ test.describe('mobile navigation', () => {
     await expect(navigation).not.toBeVisible()
   })
 
-  test('hides desktop controls and presents mobile cards', async ({ page }) => {
+  test('closes the compact navigation sheet at the desktop breakpoint', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Open navigation' }).click()
+    const navigation = page.getByRole('navigation', { name: 'Mobile navigation' })
+    await expect(navigation).toBeVisible()
+
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await expect(navigation).not.toBeVisible()
+    await expect(page.getByRole('link', { name: 'Features' })).toBeVisible()
+  })
+
+  test('keeps both filters full width and filters mobile cards', async ({ page }) => {
     await page.goto('/library/listen-later')
     await seedListenLaterItems(page, [
       listenLaterSeed({
@@ -830,9 +864,16 @@ test.describe('mobile navigation', () => {
     await expect(mobileCard.getByText('Not listened', { exact: true })).toBeVisible()
     await expect(mobileCard.getByRole('button', { name: 'Open menu' })).toBeVisible()
     await expect(platformLink).toBeVisible()
+    await expectMinTouchTarget(platformLink)
+    await expectStacked(page.locator('#link-url'), addLinkButton(page))
+    await expectStacked(page.locator('#search-title'), page.locator('#search-artist'))
     await expect
-      .poll(() => platformLink.evaluate((link) => link.getBoundingClientRect().height))
-      .toBeGreaterThanOrEqual(44)
+      .poll(() =>
+        page.evaluate(
+          () => document.documentElement.scrollWidth <= document.documentElement.clientWidth
+        )
+      )
+      .toBe(true)
   })
 
   test('opens a Deezer album from a mobile card', async ({ page }) => {

--- a/tests/e2e/listen_later.spec.ts
+++ b/tests/e2e/listen_later.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import type { Page } from '@playwright/test'
+import type { Locator, Page } from '@playwright/test'
 
 const SPOTIFY_URL = 'https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC'
 
@@ -26,6 +26,35 @@ const mockMetadataResponse = {
   },
 }
 
+interface ListenLaterItemSeed {
+  id: string
+  title: string
+  releaseDate?: string
+  artists: string[]
+  itemType: 'track' | 'album'
+  hasBeenListened: boolean
+  addedAt: number
+  externalLinks?: {
+    platform: string
+    label: string
+    url: string
+    category: 'stream' | 'buy'
+  }[]
+}
+
+type ListenLaterSeedOverrides = Pick<ListenLaterItemSeed, 'id' | 'title'> &
+  Partial<Omit<ListenLaterItemSeed, 'id' | 'title'>>
+
+function listenLaterSeed(overrides: ListenLaterSeedOverrides): ListenLaterItemSeed {
+  return {
+    artists: ['Artist'],
+    itemType: 'album',
+    hasBeenListened: false,
+    addedAt: 1,
+    ...overrides,
+  }
+}
+
 // The "Add" link button shares its accessible-name prefix with the sortable
 // "Added" column header, so it must be matched exactly.
 const addLinkButton = (page: Page) => page.getByRole('button', { name: 'Add', exact: true })
@@ -35,12 +64,54 @@ const addLinkButton = (page: Page) => page.getByRole('button', { name: 'Add', ex
 const dialogField = (page: Page, label: string) =>
   page.getByRole('dialog').getByLabel(label, { exact: true })
 
+async function expectMinTouchTarget(locator: Locator) {
+  await expect(locator).toBeVisible()
+  await expect
+    .poll(() => locator.evaluate((element) => element.getBoundingClientRect().height))
+    .toBeGreaterThanOrEqual(44)
+}
+
+async function expectAllMinTouchTargets(locator: Locator) {
+  const count = await locator.count()
+  expect(count).toBeGreaterThan(0)
+  for (let index = 0; index < count; index += 1) {
+    await expectMinTouchTarget(locator.nth(index))
+  }
+}
+
 async function addSpotifyItem(page: Page) {
   await page.getByPlaceholder('Paste a link from Spotify').fill(SPOTIFY_URL)
   await addLinkButton(page).click()
   await expect(page.getByRole('heading', { name: 'Add to Listen Later' })).toBeVisible()
   await page.getByRole('button', { name: 'Add to List' }).click()
   await expect(page.getByRole('dialog')).not.toBeVisible()
+}
+async function seedListenLaterItems(page: Page, items: ListenLaterItemSeed[]) {
+  await page.evaluate(async (seed) => {
+    const db = await new Promise<IDBDatabase>((resolve, reject) => {
+      const request = indexedDB.open('listenLaterDB', 3)
+      request.onupgradeneeded = () => {
+        const database = request.result
+        if (!database.objectStoreNames.contains('listenLaterList')) {
+          database.createObjectStore('listenLaterList', { keyPath: 'id', autoIncrement: true })
+        }
+      }
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      const transaction = db.transaction('listenLaterList', 'readwrite')
+      const store = transaction.objectStore('listenLaterList')
+      store.clear()
+      for (const item of seed) store.add(item)
+      transaction.oncomplete = () => resolve()
+      transaction.onerror = () => reject(transaction.error)
+    })
+
+    db.close()
+  }, items)
+  await page.reload()
 }
 
 test.describe('listen later page', () => {
@@ -477,5 +548,240 @@ test.describe('artist-only search', () => {
     const requestUrl = new URL(searchUrls[0])
     expect(requestUrl.searchParams.get('artist')).toBe('angele')
     expect(requestUrl.searchParams.has('q')).toBe(false)
+  })
+})
+
+test.describe('table filters', () => {
+  test('filters rendered rows', async ({ page }) => {
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      {
+        id: 'album-item',
+        title: 'Album result',
+        releaseDate: '2024-01-01',
+        artists: ['Album Artist'],
+        itemType: 'album',
+        hasBeenListened: false,
+        addedAt: 1,
+      },
+      {
+        id: 'track-item',
+        title: 'Track result',
+        releaseDate: '2024-01-02',
+        artists: ['Track Artist'],
+        itemType: 'track',
+        hasBeenListened: false,
+        addedAt: 2,
+      },
+    ])
+
+    await page.getByRole('button', { name: 'Type: All', exact: true }).click()
+    await page.getByRole('option', { name: 'Albums', exact: true }).click()
+
+    await expect(page.getByText('1 item(s)')).toBeVisible()
+    await expect(page.getByRole('row').filter({ hasText: 'Album result' })).toBeVisible()
+    await expect(page.getByRole('row').filter({ hasText: 'Track result' })).not.toBeVisible()
+  })
+})
+
+test.describe('reduced motion', () => {
+  test.use({ viewport: { width: 320, height: 568 } })
+
+  test('removes sheet travel under reduced motion', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' })
+    await page.goto('/')
+    await page.getByRole('button', { name: 'Open navigation' }).click()
+    const sheet = page.getByRole('dialog')
+
+    await expect(sheet).toBeVisible()
+    const motion = await sheet.evaluate((element) => ({
+      reduced: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+      transforms: element.getAnimations().flatMap((animation) => {
+        if (!(animation.effect instanceof KeyframeEffect)) return []
+        return animation.effect.getKeyframes().map((frame) => String(frame.transform ?? 'none'))
+      }),
+    }))
+    expect(motion.reduced).toBe(true)
+    expect(motion.transforms.length).toBeGreaterThan(0)
+    expect(
+      motion.transforms.filter(
+        (transform) => transform !== 'none' && transform !== 'matrix(1, 0, 0, 1, 0, 0)'
+      )
+    ).toEqual([])
+  })
+})
+
+test.describe('mobile breakpoint controls', () => {
+  test.use({ viewport: { width: 700, height: 800 } })
+
+  test('keeps interactive controls at least 44px', async ({ page }) => {
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      listenLaterSeed({
+        id: 'touch-target-item',
+        title: 'Touch target item',
+        externalLinks: [
+          {
+            platform: 'deezer',
+            label: 'Deezer',
+            url: 'https://www.deezer.com/album/1',
+            category: 'stream',
+          },
+        ],
+      }),
+    ])
+
+    const mobileCard = page.locator('#mobile-item-touch-target-item')
+    const controls = [
+      page.locator('#link-url'),
+      addLinkButton(page),
+      page.locator('#search-type'),
+      page.locator('#search-title'),
+      page.locator('#search-artist'),
+      page.getByRole('button', { name: 'Status: All', exact: true }),
+      page.getByRole('button', { name: 'Type: All', exact: true }),
+      page.getByRole('button', { name: 'Sort: None', exact: true }),
+      page.getByRole('button', { name: 'Columns', exact: true }),
+      mobileCard.getByRole('button', { name: 'Open menu' }),
+      page.getByRole('button', { name: 'Previous' }),
+      page.getByRole('button', { name: 'Next' }),
+      page.getByRole('button', { name: 'Open navigation' }),
+      page.getByRole('link', { name: 'MusicKeeper home', exact: true }),
+    ]
+
+    for (const control of controls) await expectMinTouchTarget(control)
+
+    const selectTriggers = [
+      page.locator('#search-type'),
+      page.getByRole('button', { name: 'Status: All', exact: true }),
+      page.getByRole('button', { name: 'Type: All', exact: true }),
+      page.getByRole('button', { name: 'Sort: None', exact: true }),
+    ]
+    for (const trigger of selectTriggers) {
+      await trigger.click()
+      await expectAllMinTouchTargets(
+        page.locator('[data-slot="select-content"][data-state="open"]').getByRole('option')
+      )
+      await page.keyboard.press('Escape')
+    }
+
+    await page.getByRole('button', { name: 'Columns', exact: true }).click()
+    await expectAllMinTouchTargets(page.getByRole('menuitemcheckbox'))
+    await page.keyboard.press('Escape')
+
+    await mobileCard.getByRole('button', { name: 'Open menu' }).click()
+    await expectAllMinTouchTargets(page.getByRole('menuitem'))
+    await page.keyboard.press('Escape')
+
+    await page.getByRole('button', { name: 'Open navigation' }).click()
+    const navigation = page.getByRole('navigation', { name: 'Mobile navigation' })
+    await expectMinTouchTarget(navigation.getByRole('link', { name: 'Features' }))
+    await expectMinTouchTarget(navigation.getByRole('link', { name: 'Blog' }))
+    await expectMinTouchTarget(page.getByRole('button', { name: 'Toggle theme' }))
+    await page.getByRole('button', { name: 'Toggle theme' }).click()
+    await expectAllMinTouchTargets(page.getByRole('menuitem'))
+    await page.keyboard.press('Escape')
+    await expectMinTouchTarget(page.getByRole('button', { name: 'Close', exact: true }))
+  })
+})
+
+test.describe('mobile navigation', () => {
+  test.use({ viewport: { width: 320, height: 568 } })
+
+  test('provides compact navigation on narrow screens', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('button', { name: 'Open navigation' })).toBeVisible()
+  })
+
+  test('opens a Deezer album from a mobile card', async ({ page }) => {
+    await page.context().route('https://www.deezer.com/**', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'text/html',
+        body: '<title>Deezer album</title>',
+      })
+    )
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      listenLaterSeed({
+        id: 'deezer-item',
+        title: 'Deezer album',
+        externalLinks: [
+          {
+            platform: 'deezer',
+            label: 'Deezer',
+            url: 'https://www.deezer.com/album/1',
+            category: 'stream',
+          },
+        ],
+      }),
+    ])
+
+    const popupPromise = page.waitForEvent('popup')
+    await page.locator('#mobile-item-deezer-item').getByRole('link', { name: 'Deezer' }).click()
+    const popup = await popupPromise
+    await expect(popup).toHaveURL('https://www.deezer.com/album/1')
+  })
+
+  test('marks an item as listened from a mobile card', async ({ page }) => {
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      listenLaterSeed({
+        id: 'mobile-listened-item',
+        title: 'Mobile listened item',
+      }),
+    ])
+
+    const mobileCard = page.locator('#mobile-item-mobile-listened-item')
+    await expect(mobileCard.getByText('Not listened', { exact: true })).toBeVisible()
+    await mobileCard.getByRole('button', { name: 'Open menu' }).click()
+    await page.getByRole('menuitem', { name: 'Mark as listened' }).click()
+    await expect(mobileCard.getByText('Listened', { exact: true })).toBeVisible()
+
+    await page.reload()
+    await expect(mobileCard.getByText('Listened', { exact: true })).toBeVisible()
+  })
+
+  test('deletes an item through confirmation from a mobile card', async ({ page }) => {
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      listenLaterSeed({
+        id: 'mobile-delete-item',
+        title: 'Mobile delete item',
+      }),
+    ])
+
+    const mobileCard = page.locator('#mobile-item-mobile-delete-item')
+    await mobileCard.getByRole('button', { name: 'Open menu' }).click()
+    await page.getByRole('menuitem', { name: 'Delete' }).click()
+    await expect(page.getByRole('heading', { name: 'Are you sure?' })).toBeVisible()
+    await page.getByRole('button', { name: 'Confirm' }).click()
+    await expect(mobileCard).not.toBeVisible()
+    await expect(page.getByText('Add your first item by searching above')).toBeVisible()
+
+    await page.reload()
+    await expect(mobileCard).not.toBeVisible()
+  })
+
+  test('provides mobile sorting for saved items', async ({ page }) => {
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      {
+        id: 'mobile-sort-item',
+        title: 'Mobile sort item',
+        releaseDate: '2024-01-01',
+        artists: ['Mobile Artist'],
+        itemType: 'album',
+        hasBeenListened: false,
+        addedAt: 1,
+      },
+    ])
+
+    await expect(page.getByRole('button', { name: 'Sort: None', exact: true })).toBeVisible()
+    await page.getByRole('button', { name: 'Sort: None', exact: true }).click()
+    await page.getByRole('option', { name: 'Artists (A–Z)', exact: true }).click()
+    await expect(
+      page.getByRole('button', { name: 'Sort: Artists (A–Z)', exact: true })
+    ).toBeVisible()
   })
 })

--- a/tests/e2e/listen_later.spec.ts
+++ b/tests/e2e/listen_later.spec.ts
@@ -704,6 +704,7 @@ test.describe('mobile breakpoint controls', () => {
       page.getByRole('button', { name: 'Sort: None', exact: true }),
       page.getByRole('button', { name: 'Columns', exact: true }),
       mobileCard.getByRole('button', { name: 'Open menu' }),
+      mobileCard.getByRole('link', { name: 'Deezer' }),
       page.getByRole('button', { name: 'Previous' }),
       page.getByRole('button', { name: 'Next' }),
       page.getByRole('button', { name: 'Open navigation' }),
@@ -759,6 +760,79 @@ test.describe('mobile navigation', () => {
     await navigation.getByRole('link', { name: 'Features' }).click()
     await expect(page).toHaveURL(/\/#features$/)
     await expect(navigation).not.toBeVisible()
+  })
+
+  test('hides desktop controls and presents mobile cards', async ({ page }) => {
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      listenLaterSeed({
+        id: 'filter-listened-track',
+        title: 'Listened track',
+        itemType: 'track',
+        hasBeenListened: true,
+      }),
+      listenLaterSeed({
+        id: 'filter-unlistened-album',
+        title: 'Unlistened album',
+      }),
+    ])
+
+    for (const name of ['Status: All', 'Type: All']) {
+      const filter = page.getByRole('button', { name, exact: true })
+      await expect(filter).toBeVisible()
+      await expect
+        .poll(() => filter.evaluate((element) => element.getBoundingClientRect().width))
+        .toBeGreaterThanOrEqual(250)
+    }
+
+    const listenedTrack = page.locator('#mobile-item-filter-listened-track')
+    const unlistenedAlbum = page.locator('#mobile-item-filter-unlistened-album')
+
+    await page.getByRole('button', { name: 'Status: All', exact: true }).click()
+    await page.getByRole('option', { name: 'Listened', exact: true }).click()
+    await expect(listenedTrack).toBeVisible()
+    await expect(unlistenedAlbum).not.toBeVisible()
+
+    await page.getByRole('button', { name: 'Status: Listened', exact: true }).click()
+    await page.getByRole('option', { name: 'All', exact: true }).click()
+    await page.getByRole('button', { name: 'Type: All', exact: true }).click()
+    await page.getByRole('option', { name: 'Albums', exact: true }).click()
+    await expect(listenedTrack).not.toBeVisible()
+    await expect(unlistenedAlbum).toBeVisible()
+  })
+
+  test('retains shared controls and presents mobile cards', async ({ page }) => {
+    const longTitle = 'ColumnChooserItem'.repeat(24)
+    await page.goto('/library/listen-later')
+    await seedListenLaterItems(page, [
+      listenLaterSeed({
+        id: 'column-chooser-item',
+        title: longTitle,
+        itemType: 'track',
+        externalLinks: [
+          {
+            platform: 'spotify',
+            label: 'Spotify',
+            url: 'https://open.spotify.com',
+            category: 'stream',
+          },
+        ],
+      }),
+    ])
+
+    await expect(page.getByRole('button', { name: 'Columns', exact: true })).toBeVisible()
+    const mobileCard = page.locator('#mobile-item-column-chooser-item')
+    const platformLink = mobileCard.getByRole('link', { name: 'Spotify' })
+
+    await expect(mobileCard).toContainText(longTitle)
+    await expect(mobileCard).toContainText('Artist')
+    await expect(mobileCard.getByText('Track', { exact: true })).toBeVisible()
+    await expect(mobileCard.getByText('Not listened', { exact: true })).toBeVisible()
+    await expect(mobileCard.getByRole('button', { name: 'Open menu' })).toBeVisible()
+    await expect(platformLink).toBeVisible()
+    await expect
+      .poll(() => platformLink.evaluate((link) => link.getBoundingClientRect().height))
+      .toBeGreaterThanOrEqual(44)
   })
 
   test('opens a Deezer album from a mobile card', async ({ page }) => {

--- a/tests/e2e/listen_later.spec.ts
+++ b/tests/e2e/listen_later.spec.ts
@@ -647,14 +647,23 @@ test.describe('desktop sorting', () => {
 
     await page.setViewportSize({ width: 320, height: 568 })
     await expect(columnChooser).not.toBeVisible()
-    const customSort = page.getByRole('button', {
-      name: 'Sort: Artists (descending)',
+    const mobileSortTrigger = page.getByRole('button', {
+      name: 'Sort: Artists (Z–A)',
       exact: true,
     })
-    await expect(customSort).toBeVisible()
-    await customSort.click()
-    await page.getByRole('option', { name: 'None', exact: true }).click()
-    await expect(page.getByRole('button', { name: 'Sort: None', exact: true })).toBeVisible()
+    await expect(mobileSortTrigger).toBeVisible()
+    await mobileSortTrigger.click()
+    await page.getByRole('option', { name: 'Added (oldest)', exact: true }).click()
+    await expect(
+      page.getByRole('button', { name: 'Sort: Added (oldest)', exact: true })
+    ).toBeVisible()
+
+    await page.setViewportSize({ width: 1280, height: 800 })
+    await page.getByRole('button', { name: 'Title, not sorted', exact: true }).click()
+    await page.setViewportSize({ width: 320, height: 568 })
+    await expect(
+      page.getByRole('button', { name: 'Sort: Title (ascending)', exact: true })
+    ).toBeVisible()
   })
 })
 
@@ -728,7 +737,7 @@ test.describe('mobile breakpoint controls', () => {
       page.locator('#search-artist'),
       page.getByRole('button', { name: 'Status: All', exact: true }),
       page.getByRole('button', { name: 'Type: All', exact: true }),
-      page.getByRole('button', { name: 'Sort: None', exact: true }),
+      page.getByRole('button', { name: 'Sort: Added (oldest)', exact: true }),
       mobileCard.getByRole('button', { name: 'Open menu' }),
       mobileCard.getByRole('link', { name: 'Deezer' }),
       page.getByRole('button', { name: 'Previous' }),
@@ -743,7 +752,7 @@ test.describe('mobile breakpoint controls', () => {
       page.locator('#search-type'),
       page.getByRole('button', { name: 'Status: All', exact: true }),
       page.getByRole('button', { name: 'Type: All', exact: true }),
-      page.getByRole('button', { name: 'Sort: None', exact: true }),
+      page.getByRole('button', { name: 'Sort: Added (oldest)', exact: true }),
     ]
     for (const trigger of selectTriggers) {
       await trigger.click()
@@ -970,7 +979,7 @@ test.describe('mobile navigation', () => {
     ])
     const mobileItems = page.locator('article[id^="mobile-item-"]')
 
-    await page.getByRole('button', { name: 'Sort: None', exact: true }).click()
+    await page.getByRole('button', { name: 'Sort: Added (oldest)', exact: true }).click()
     await page.getByRole('option', { name: 'Artists (A–Z)', exact: true }).click()
     await expect
       .poll(() => mobileItems.evaluateAll((items) => items.map((item) => item.id)))

--- a/tests/unit/inertia/components/data-table/data_table_row_transitions.spec.ts
+++ b/tests/unit/inertia/components/data-table/data_table_row_transitions.spec.ts
@@ -1,0 +1,51 @@
+import { test } from '@japa/runner'
+import {
+  rowIn,
+  rowOut,
+} from '../../../../../inertia/components/data-table/data_table_row_transitions.js'
+
+/**
+ * The transitions read `window.matchMedia` and `getComputedStyle` as globals, so
+ * the OS preference is emulated here instead of in a browser: an end-to-end
+ * check would have to import the module over HTTP, which only resolves against
+ * the Vite dev server and 404s on a production build.
+ */
+function withReducedMotion<T>(reduced: boolean, run: () => T): T {
+  const globals = globalThis as unknown as { window?: unknown; getComputedStyle?: unknown }
+  const previousWindow = globals.window
+  const previousGetComputedStyle = globals.getComputedStyle
+
+  globals.window = {
+    matchMedia: (query: string) => ({ matches: reduced && query.includes('reduce') }),
+  }
+  globals.getComputedStyle = () => ({ opacity: '1', transform: 'none' })
+
+  try {
+    return run()
+  } finally {
+    globals.window = previousWindow
+    globals.getComputedStyle = previousGetComputedStyle
+  }
+}
+
+const node = {} as Element
+
+test.group('Data table row transitions', () => {
+  test('drops row travel when the OS asks for reduced motion', async ({ assert }) => {
+    withReducedMotion(true, () => {
+      assert.equal(rowIn(node).duration, 0)
+      assert.equal(rowOut(node).duration, 0)
+      assert.isUndefined(rowIn(node).css)
+      assert.isUndefined(rowOut(node).css)
+    })
+  })
+
+  test('animates rows when motion is allowed', async ({ assert }) => {
+    withReducedMotion(false, () => {
+      assert.equal(rowIn(node).duration, 180)
+      assert.equal(rowOut(node).duration, 160)
+      assert.isFunction(rowIn(node).css)
+      assert.isFunction(rowOut(node).css)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Make MusicKeeper usable on phone-sized viewports without requiring horizontal scrolling or desktop table interactions.

## What changed

- Add responsive mobile card layout for Listen Later items.
- Keep title, artist, type, listened status, actions, and external links visible in each card.
- Add compact Sheet navigation below the `md` breakpoint.
- Stack link-import and search controls on narrow screens.
- Add mobile sorting controls for artist A–Z, newest added, and oldest added.
- Preserve filters for type and listened status with full-width touch-friendly controls.
- Increase interactive mobile controls to at least 44px.
- Add accessible sort labels and `aria-sort` state.
- Remove row-height animation that caused mobile layout reflow; keep reduced-motion-safe transitions.
- Add end-to-end coverage for filtering, deletion, compact navigation, and mobile sorting.

## User flow covered

1. Open Listen Later on a phone.
2. Open an external album link, including Deezer.
3. Sort by artist or added date.
4. Filter to albums and not-listened items.
5. Mark an item as listened.
6. Delete an item through the confirmation dialog.

## Verification

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test` — 218 passed
- `pnpm run test:e2e` — 17 passed
- Focused mobile regression tests passed at `390x844`.

## Preview

Opening this PR triggers `.github/workflows/pr-preview.yml`:

- Builds the production Docker image.
- Deploys an isolated Coolify preview.
- Comments the live preview URL on this PR.
- Runs the Playwright suite against that deployed URL.

## Review note

The mobile `Columns` control is intentionally retained from the shared toolbar, but currently affects the desktop table only; mobile cards use a fixed information hierarchy.