### PR TITLE
fix(search): allow artist-only searches

### DIFF
--- a/inertia/pages/listen-later.svelte
+++ b/inertia/pages/listen-later.svelte
@@ -77,12 +77,15 @@
     focusedResultIndex = -1
     try {
       const params = new URLSearchParams({
-        q: debouncedSearch.current,
         type: searchType,
       })
 
+      if (hasSearchTerm) {
+        params.set('q', debouncedSearch.current)
+      }
+
       if (hasArtist) {
-        params.append('artist', debouncedArtist.current)
+        params.set('artist', debouncedArtist.current)
       }
 
       const response = await fetch(`/library/listen-later?${params.toString()}`, {

--- a/tests/e2e/listen_later.spec.ts
+++ b/tests/e2e/listen_later.spec.ts
@@ -448,3 +448,34 @@ test.describe('delete item', () => {
     await expect(page.getByText('"Never Gonna Give You Up" removed from your list')).toBeVisible()
   })
 })
+
+test.describe('artist-only search', () => {
+  test('omits the empty title query from the search request', async ({ page }) => {
+    const searchUrls: string[] = []
+
+    await page.route('**/library/listen-later*', async (route) => {
+      const url = new URL(route.request().url())
+
+      if (!url.searchParams.has('type')) {
+        await route.continue()
+        return
+      }
+
+      searchUrls.push(url.toString())
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ serializedItems: [] }),
+      })
+    })
+
+    await page.goto('/library/listen-later')
+    await page.getByLabel('Artist name', { exact: true }).fill('angele')
+
+    await expect.poll(() => searchUrls.length).toBeGreaterThan(0)
+
+    const requestUrl = new URL(searchUrls[0])
+    expect(requestUrl.searchParams.get('artist')).toBe('angele')
+    expect(requestUrl.searchParams.has('q')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- omit the empty title query from artist-only searches
- preserve artist filtering and existing title search behavior
- add an E2E regression test for the generated request

## Verification
- pnpm typecheck
- pnpm test (218 passed)
- pnpm exec playwright test tests/e2e/listen_later.spec.ts -g "omits the empty title query"