### PR TITLE
refactor(listen-later): route every list write through one store

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,41 @@
+# MusicKeeper
+
+A place to keep the music you mean to listen to. Someone hears about a track or an album, pastes a link or searches for it, and it waits in their list until they get to it.
+
+## Language
+
+### The list
+
+**Listen Later List**:
+The collection of music one person has saved to listen to later. It lives on their device only — there is no account and nothing is shared.
+_Avoid_: library, saved items, watchlist, queue
+
+**Listen Later Item**:
+One entry in the Listen Later List: a Music Item plus when it was saved and whether it has been listened to.
+_Avoid_: saved track, record, row, entry
+
+**Music Item**:
+A track or an album as identified by its metadata — title, artists, release date. What a Listen Later Item is made of, before anything about saving it.
+_Avoid_: song, release, media
+
+**Listened**:
+Whether the person has heard a Listen Later Item. A state they set themselves, not something the app observes; an item stays in the list once listened.
+_Avoid_: played, done, watched, completed
+
+### Adding to the list
+
+**Source URL**:
+The link a Listen Later Item was pasted from, kept as the origin of the entry. Absent for items added from a search.
+_Avoid_: original link, permalink
+
+**External Link**:
+A way to reach a Music Item on a music platform, either to stream it or to buy it. Found for an item, not entered by the person.
+_Avoid_: platform link, streaming link
+
+**Duplicate**:
+A Listen Later Item that is the same recording as one being added: same title and the same set of artists.
+_Avoid_: existing item, match, collision
+
+**Another Version**:
+A recording that shares a title with a Listen Later Item but not its exact set of artists — a remix, a guest version, a re-recording. Not a Duplicate, and adding it is legitimate: "Nightcall" by Kavinsky and "Nightcall" by Kavinsky, Angèle & Phoenix are two different recordings, and the difference is not always stated in the title.
+_Avoid_: variant, alternate, near-duplicate

--- a/docs/adr/0001-optimistic-listen-later-updates.md
+++ b/docs/adr/0001-optimistic-listen-later-updates.md
@@ -1,0 +1,15 @@
+# Listen Later writes update the list in memory, without re-reading storage
+
+Every write to the Listen Later List — add, remove, toggle listened — performs one storage operation and then updates the in-memory list locally, instead of re-reading the whole list afterwards. Reads are always ordered oldest first, which is what makes appending a new item correct.
+
+## Considered options
+
+The alternative was **authoritative order**: every write returns the full sorted list, so the display can never disagree with what is stored. It was rejected because the divergence it protects against does not exist — the displayed order is the stored order, appending a new item puts it exactly where a reload would, and the table re-sorts on its own as soon as a sort is chosen. It cost two storage round trips per interaction to guarantee something already true.
+
+Before this decision the three writes behaved in three different ways: add appended in memory, while remove and toggle each re-read and re-sorted the entire list. The symmetry was worth having; it was cheaper to make all three optimistic than all three authoritative.
+
+## Consequences
+
+- A write that fails must leave the in-memory list untouched, so storage operations reject instead of swallowing errors, and every caller catches and reports.
+- Appending assumes the oldest-first order. If that default order ever changes, appending becomes wrong and the callers have to re-read instead. The append sites say so in a comment.
+- Nothing notices a second tab writing to the same list. That was already true — the old re-reads would have caught such a change by accident, on the next interaction, not by design. If the list ever needs to be correct across tabs, this decision is the one to revisit.

--- a/inertia/components/trackItem.svelte
+++ b/inertia/components/trackItem.svelte
@@ -4,6 +4,8 @@
   import type { ExternalLink } from '../../src/domain/music_item'
   import CoverArt from '~/components/CoverArt.svelte'
   import Skeleton from 'boneyard-js/svelte'
+  import { toast } from 'svelte-sonner'
+  import { listenLaterStorage } from '../../src/infrastructure/storage/listen_later_storage'
 
   let {
     listenLaterItems = $bindable(),
@@ -32,27 +34,29 @@
   }
 
   async function addToListenLater(item: MusicItem) {
-    const itemTolistenLater: ListenLaterItem = {
-      ...item,
-      hasBeenListened: false,
-      addedAt: new Date(),
-      externalLinks: [],
-    }
-    const dbRequest = indexedDB.open('listenLaterDB', 3)
+    // Links resolve in the background: the item is saved and on screen first.
+    try {
+      const stored = await listenLaterStorage.add({
+        id: item.id,
+        title: item.title,
+        releaseDate: item.releaseDate,
+        length: item.length,
+        artists: item.artists,
+        albumName: item.albumName,
+        itemType: item.itemType,
+        coverArt: item.coverArt,
+        externalLinks: [],
+      })
 
-    dbRequest.onsuccess = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
-      const transaction = db.transaction('listenLaterList', 'readwrite')
-      const store = transaction.objectStore('listenLaterList')
-
-      const addRequest = store.add(itemTolistenLater)
-      addRequest.onsuccess = () => {
-        listenLaterItems = [...listenLaterItems, itemTolistenLater]
-        void backfillExternalLinks(item)
-      }
-      addRequest.onerror = (error) => {
-        console.error('Error adding item to listen later list:', error)
-      }
+      // ponytail: appending assumes the store's oldest-first order, which puts a
+      // new item last. If that default order ever changes, replace this with a
+      // getAll().
+      listenLaterItems = [...listenLaterItems, stored]
+      toast.success(`"${item.title}" added to your list`)
+      void backfillExternalLinks(item)
+    } catch (error) {
+      console.error('Error adding item to listen later list:', error)
+      toast.error(`Could not add "${item.title}"`)
     }
   }
 
@@ -63,48 +67,31 @@
     const externalLinks = await fetchExternalLinks(item)
     if (!externalLinks.length) return
 
-    const dbRequest = indexedDB.open('listenLaterDB', 3)
-    dbRequest.onsuccess = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
-      const store = db.transaction('listenLaterList', 'readwrite').objectStore('listenLaterList')
-
-      const getRequest = store.get(item.id)
-      getRequest.onsuccess = () => {
-        const stored = getRequest.result
-        if (!stored) return
-
-        store.put({ ...stored, externalLinks })
-        listenLaterItems = listenLaterItems.map((existing: ListenLaterItem) =>
-          existing.id === item.id ? { ...existing, externalLinks } : existing
-        )
-      }
-      getRequest.onerror = (error) => {
-        console.error('Error backfilling external links:', error)
-      }
+    try {
+      const updated = await listenLaterStorage.updateExternalLinks(item.id, externalLinks)
+      if (!updated) return
+      listenLaterItems = listenLaterItems.map((existing: ListenLaterItem) =>
+        existing.id === item.id ? { ...existing, externalLinks } : existing
+      )
+    } catch (error) {
+      console.error('Error backfilling external links:', error)
     }
   }
 
-  function removeFromListenLater(itemId: string) {
-    const dbRequest = indexedDB.open('listenLaterDB', 3)
-
-    dbRequest.onsuccess = (event) => {
-      const db = (event.target as IDBOpenDBRequest).result
-      const transaction = db.transaction('listenLaterList', 'readwrite')
-      const store = transaction.objectStore('listenLaterList')
-
-      const deleteRequest = store.delete(itemId)
-      deleteRequest.onsuccess = () => {
-        listenLaterItems = listenLaterItems.filter((item: ListenLaterItem) => item.id !== itemId)
-      }
-      deleteRequest.onerror = (error) => {
-        console.error('Error removing item from listen later list:', error)
-      }
+  async function removeFromListenLater(item: MusicItem) {
+    try {
+      await listenLaterStorage.remove(item.id)
+      listenLaterItems = listenLaterItems.filter((i: ListenLaterItem) => i.id !== item.id)
+      toast.success(`"${item.title}" removed from your list`)
+    } catch (error) {
+      console.error('Error removing item from listen later list:', error)
+      toast.error(`Could not remove "${item.title}"`)
     }
   }
 
   function toggleListenLater(item: MusicItem) {
     if (listenLaterItems.some((i: ListenLaterItem) => i.id === item.id)) {
-      removeFromListenLater(item.id)
+      removeFromListenLater(item)
     } else {
       addToListenLater(item)
     }

--- a/inertia/pages/listen-later.svelte
+++ b/inertia/pages/listen-later.svelte
@@ -15,6 +15,10 @@
   import { ListenLaterItem, MusicItem, SearchType } from '../../src/domain/music_item'
   import type { ExternalLink } from '../../src/domain/music_item'
   import type { LinkMetadata } from '../../src/infrastructure/services/link_metadata.service'
+  import {
+    findDuplicate,
+    listenLaterStorage,
+  } from '../../src/infrastructure/storage/listen_later_storage'
   import LibraryLayout from '../layouts/libraryLayout.svelte'
 
   let { serializedItems = [] } = $props()
@@ -24,7 +28,6 @@
   let listenLaterItems = $state([]) as ListenLaterItem[]
   let isSearching = $state(false)
   let isOffline = $state(typeof navigator !== 'undefined' ? !navigator.onLine : false)
-  let db: IDBDatabase
 
   // Listen for online/offline events
   $effect(() => {
@@ -169,133 +172,39 @@
     return () => clearTimeout(timeout)
   })
 
-  const request = indexedDB.open('listenLaterDB', 3)
+  $effect(() => {
+    void loadListenLaterItems()
+  })
 
-  request.onupgradeneeded = (event) => {
-    db = event.target?.result
-    const oldVersion = event.oldVersion
-
-    // Create object store for fresh installs
-    if (oldVersion < 1) {
-      db.createObjectStore('listenLaterList', {
-        keyPath: 'id',
-        autoIncrement: true,
-      })
-    }
-
-    // Migration from version 1 to 2: add type field to existing items
-    if (oldVersion < 2) {
-      const transaction = event.target.transaction
-      const objectStore = transaction.objectStore('listenLaterList')
-      let counter = 0
-
-      objectStore.openCursor().onsuccess = (cursorEvent: IDBCursor) => {
-        const cursor = cursorEvent.target.result
-        if (cursor) {
-          const item = cursor.value
-          // Add type field to existing items (default to 'track')
-          if (!item.type) {
-            item.type = 'track'
-          }
-          // Add addedAt field to existing items (use counter to preserve order)
-          if (!item.addedAt) {
-            item.addedAt = counter++
-          }
-          cursor.update(item)
-          cursor.continue()
-        }
-      }
-    }
-
-    // Migration from version 2 to 3: add externalLinks field to existing items
-    if (oldVersion < 3) {
-      const transaction = event.target.transaction
-      const objectStore = transaction.objectStore('listenLaterList')
-
-      objectStore.openCursor().onsuccess = (cursorEvent: IDBCursor) => {
-        const cursor = cursorEvent.target.result
-        if (cursor) {
-          const item = cursor.value
-          if (!item.externalLinks) {
-            item.externalLinks = []
-            cursor.update(item)
-          }
-          cursor.continue()
-        }
-      }
+  async function loadListenLaterItems() {
+    try {
+      listenLaterItems = await listenLaterStorage.getAll()
+    } catch (error) {
+      console.error('Error loading listen later list:', error)
+      toast.error('Failed to load your list')
     }
   }
 
-  request.onsuccess = (event) => {
-    db = event.target.result
-    const transaction = db.transaction('listenLaterList', 'readwrite')
-    const store = transaction.objectStore('listenLaterList')
-
-    const getRequest = store.getAll()
-    getRequest.onsuccess = () => {
-      sortListenLaterItems(getRequest)
+  async function handleListen(item: ListenLaterItem) {
+    try {
+      const updated = await listenLaterStorage.toggleListened(item.id)
+      if (updated) {
+        listenLaterItems = listenLaterItems.map((i) => (i.id === updated.id ? updated : i))
+      }
+    } catch (error) {
+      console.error('Error updating item:', error)
+      toast.error(`Could not update "${item.title}"`)
     }
   }
 
-  function handleListen(item: ListenLaterItem): void {
-    // Toggle hasBeenListened status
-    const transaction = db.transaction(['listenLaterList'], 'readwrite')
-    const objectStore = transaction.objectStore('listenLaterList')
-
-    const getRequest = objectStore.get(item.id)
-    getRequest.onsuccess = () => {
-      const data = getRequest.result
-
-      if (data) {
-        // Toggle the hasBeenListened value
-        data.hasBeenListened = !data.hasBeenListened
-
-        // Update the item in the database
-        const updateRequest = objectStore.put(data)
-
-        updateRequest.onsuccess = () => {
-          // Refresh the list after successful update
-          const refreshTransaction = db.transaction('listenLaterList', 'readonly')
-          const refreshStore = refreshTransaction.objectStore('listenLaterList')
-          const getAllRequest = refreshStore.getAll()
-
-          getAllRequest.onsuccess = () => {
-            sortListenLaterItems(getAllRequest)
-          }
-        }
-        updateRequest.onerror = (error) => {
-          console.error('Error updating item:', error)
-        }
-      }
-    }
-
-    getRequest.onerror = (error) => {
-      console.error('Error getting item:', error)
-    }
-  }
-
-  function handleDelete(item: ListenLaterItem): void {
-    // Delete item from IndexedDB
-    const transaction = db.transaction(['listenLaterList'], 'readwrite')
-    const objectStore = transaction.objectStore('listenLaterList')
-
-    const deleteRequest = objectStore.delete(item.id)
-
-    deleteRequest.onsuccess = () => {
-      // Refresh the list after successful deletion
-      const refreshTransaction = db.transaction('listenLaterList', 'readonly')
-      const refreshStore = refreshTransaction.objectStore('listenLaterList')
-      const getAllRequest = refreshStore.getAll()
-
-      getAllRequest.onsuccess = () => {
-        sortListenLaterItems(getAllRequest)
-      }
-
+  async function handleDelete(item: ListenLaterItem) {
+    try {
+      await listenLaterStorage.remove(item.id)
+      listenLaterItems = listenLaterItems.filter((i) => i.id !== item.id)
       toast.success(`"${item.title}" removed from your list`)
-    }
-
-    deleteRequest.onerror = (error) => {
+    } catch (error) {
       console.error('Error deleting item:', error)
+      toast.error(`Could not remove "${item.title}"`)
     }
   }
 
@@ -307,16 +216,6 @@
   const triggerContent = $derived(
     types.find((t) => t.value === searchType)?.label ?? 'Select a type'
   )
-
-  function sortListenLaterItems(getAllRequest: IDBRequest<any[]>) {
-    // TODO: remove this condition when I can export and import the list
-    // this condition exists only for legacy reasons, I should remove it later
-    listenLaterItems = getAllRequest.result.sort((a: ListenLaterItem, b: ListenLaterItem) =>
-      a.addedAt instanceof Date && b.addedAt instanceof Date
-        ? a.addedAt.getTime() - b.addedAt.getTime()
-        : ((a.addedAt as unknown as number) || 0) - ((b.addedAt as unknown as number) || 0)
-    )
-  }
 
   function isValidUrl(urlString: string): boolean {
     try {
@@ -374,7 +273,7 @@
       const title = data.musicItem?.title || data.linkMetadata?.title || ''
       const artists =
         data.musicItem?.artists || (data.linkMetadata?.artist ? [data.linkMetadata.artist] : [])
-      const duplicate = findDuplicate(title, artists)
+      const duplicate = findDuplicate(listenLaterItems, title, artists)
 
       // Update dialog with fetched data
       pendingMusicItem = data.musicItem
@@ -429,41 +328,31 @@
 
     const externalLinks = await fetchExternalLinks(pendingMusicItem.id, itemType, linkUrl || undefined)
 
-    // Create ListenLaterItem from confirmed (and possibly edited) data
-    const newItem: ListenLaterItem = new ListenLaterItem({
-      id: pendingMusicItem.id,
-      title: title,
-      releaseDate: pendingMusicItem.releaseDate,
-      length: pendingMusicItem.length,
-      artists: artists,
-      albumName: albumName,
-      itemType: itemType,
-      coverArt: pendingMusicItem.coverArt,
-      hasBeenListened: false,
-      addedAt: new Date(),
-      sourceUrl: linkUrl || undefined,
-      externalLinks,
-    })
+    try {
+      const stored = await listenLaterStorage.add({
+        id: pendingMusicItem.id,
+        title,
+        releaseDate: pendingMusicItem.releaseDate,
+        length: pendingMusicItem.length,
+        artists,
+        albumName,
+        itemType,
+        coverArt: pendingMusicItem.coverArt,
+        sourceUrl: linkUrl || undefined,
+        externalLinks,
+      })
 
-    // Save to IndexedDB
-    const transaction = db.transaction('listenLaterList', 'readwrite')
-    const store = transaction.objectStore('listenLaterList')
+      // ponytail: appending assumes the store's oldest-first order, which puts a
+      // new item last. If that default order ever changes, replace this with a
+      // getAll().
+      listenLaterItems = [...listenLaterItems, stored]
 
-    const addRequest = store.add(newItem)
-
-    addRequest.onsuccess = () => {
-      // Add to the list immediately so it appears in the UI
-      listenLaterItems = [...listenLaterItems, newItem]
-
-      // Close dialog and reset state
       isConfirmDialogOpen = false
       resetPendingState()
       linkUrl = ''
 
       toast.success(`"${title}" added to your list`)
-    }
-
-    addRequest.onerror = (error) => {
+    } catch (error) {
       console.error('Error saving item to listen later list:', error)
       dialogError = 'Failed to save item. Please try again.'
     }
@@ -481,24 +370,6 @@
     existingDuplicate = null
     dialogError = null
     isDialogLoading = false
-  }
-
-  function findDuplicate(title: string, artists: string[]): ListenLaterItem | null {
-    const normalizedTitle = title.toLowerCase().trim()
-    const normalizedArtists = artists.map((a) => a.toLowerCase().trim()).sort()
-
-    return (
-      listenLaterItems.find((item) => {
-        const itemTitle = item.title.toLowerCase().trim()
-        const itemArtists = item.artists.map((a: string) => a.toLowerCase().trim()).sort()
-
-        // Match if title and at least one artist matches
-        if (itemTitle !== normalizedTitle) return false
-
-        // Check if any artist overlaps
-        return normalizedArtists.some((artist) => itemArtists.includes(artist))
-      }) || null
-    )
   }
 
   function handleViewExisting() {

--- a/src/domain/music_item.ts
+++ b/src/domain/music_item.ts
@@ -45,7 +45,7 @@ export class MusicItem {
   }
 }
 
-interface ListenLaterItemProperties extends MusicItemProperties {
+export interface ListenLaterItemProperties extends MusicItemProperties {
   hasBeenListened: boolean
   addedAt: Date
   sourceUrl?: string

--- a/src/infrastructure/storage/listen_later_storage.ts
+++ b/src/infrastructure/storage/listen_later_storage.ts
@@ -1,278 +1,342 @@
 /// <reference lib="dom" />
-import { ListenLaterItem, MusicItem } from '../../domain/music_item.js'
+import {
+  ListenLaterItem,
+  type ExternalLink,
+  type ListenLaterItemProperties,
+} from '../../domain/music_item.js'
 
 const DB_NAME = 'listenLaterDB'
 const DB_VERSION = 3
 const STORE_NAME = 'listenLaterList'
-
-export interface ListenLaterStorage {
-  open(): Promise<IDBDatabase>
-  getAll(): Promise<ListenLaterItem[]>
-  add(item: MusicItem): Promise<ListenLaterItem>
-  remove(itemId: string | number): Promise<void>
-  toggleListened(itemId: string | number): Promise<ListenLaterItem | null>
-  get(itemId: string | number): Promise<ListenLaterItem | null>
-}
-
-/**
- * Creates a ListenLaterItem from a MusicItem
- */
-export function createListenLaterItem(item: MusicItem): ListenLaterItem {
-  return {
-    ...item,
-    hasBeenListened: false,
-    addedAt: new Date(),
-  } as ListenLaterItem
-}
-
-/**
- * Sorts listen later items by addedAt date
- */
-export function sortListenLaterItems(items: ListenLaterItem[]): ListenLaterItem[] {
-  return [...items].sort((a, b) => {
-    const aTime = a.addedAt instanceof Date ? a.addedAt.getTime() : (a.addedAt as number) || 0
-    const bTime = b.addedAt instanceof Date ? b.addedAt.getTime() : (b.addedAt as number) || 0
-    return aTime - bTime
-  })
-}
-
-/**
- * Opens the IndexedDB database and handles migrations
- */
-export function openDatabase(indexedDBInstance: IDBFactory = indexedDB): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const request = indexedDBInstance.open(DB_NAME, DB_VERSION)
-
-    request.onerror = () => {
-      reject(new Error(`Failed to open database: ${request.error?.message}`))
-    }
-
-    request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
-      const db = (event.target as IDBOpenDBRequest).result
-      const oldVersion = event.oldVersion
-
-      // Create object store for fresh installs
-      if (oldVersion < 1) {
-        db.createObjectStore(STORE_NAME, {
-          keyPath: 'id',
-          autoIncrement: true,
-        })
-      }
-
-      // Migration from version 1 to 2: add type field to existing items
-      if (oldVersion < 2 && oldVersion >= 1) {
-        const transaction = (event.target as IDBOpenDBRequest).transaction
-        if (transaction) {
-          const objectStore = transaction.objectStore(STORE_NAME)
-          let counter = 0
-
-          objectStore.openCursor().onsuccess = (cursorEvent) => {
-            const cursor = (cursorEvent.target as IDBRequest<IDBCursorWithValue>).result
-            if (cursor) {
-              const item = cursor.value
-              // Add type field to existing items (default to 'track')
-              if (!item.type) {
-                item.type = 'track'
-              }
-              // Add addedAt field to existing items (use counter to preserve order)
-              if (!item.addedAt) {
-                item.addedAt = counter++
-              }
-              cursor.update(item)
-              cursor.continue()
-            }
-          }
-        }
-      }
-
-      // Migration from version 2 to 3: backfill externalLinks = [] on existing items
-      if (oldVersion < 3 && oldVersion >= 2) {
-        const transaction = (event.target as IDBOpenDBRequest).transaction
-        if (transaction) {
-          const objectStore = transaction.objectStore(STORE_NAME)
-
-          objectStore.openCursor().onsuccess = (cursorEvent) => {
-            const cursor = (cursorEvent.target as IDBRequest<IDBCursorWithValue>).result
-            if (cursor) {
-              const item = cursor.value
-              if (!item.externalLinks) {
-                item.externalLinks = []
-                const updateReq = cursor.update(item)
-                updateReq.onerror = () => {
-                  console.error(
-                    'Failed to backfill externalLinks for item %o:',
-                    item.id,
-                    updateReq.error
-                  )
-                }
-              }
-              cursor.continue()
-            }
-          }
-        }
-      }
-    }
-
-    request.onsuccess = () => {
-      resolve(request.result)
-    }
-  })
-}
-
-/**
- * Gets all items from the listen later list
- */
-export function getAllItems(db: IDBDatabase): Promise<ListenLaterItem[]> {
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readonly')
-    const store = transaction.objectStore(STORE_NAME)
-    const request = store.getAll()
-
-    request.onsuccess = () => {
-      resolve(sortListenLaterItems(request.result))
-    }
-
-    request.onerror = () => {
-      reject(new Error(`Failed to get items: ${request.error?.message}`))
-    }
-  })
-}
-
-/**
- * Gets a single item by ID
- */
-export function getItem(db: IDBDatabase, itemId: string | number): Promise<ListenLaterItem | null> {
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readonly')
-    const store = transaction.objectStore(STORE_NAME)
-    const request = store.get(itemId)
-
-    request.onsuccess = () => {
-      resolve(request.result || null)
-    }
-
-    request.onerror = () => {
-      reject(new Error(`Failed to get item: ${request.error?.message}`))
-    }
-  })
-}
-
-/**
- * Adds a music item to the listen later list
- */
-export function addItem(db: IDBDatabase, item: MusicItem): Promise<ListenLaterItem> {
-  return new Promise((resolve, reject) => {
-    const listenLaterItem = createListenLaterItem(item)
-    const transaction = db.transaction(STORE_NAME, 'readwrite')
-    const store = transaction.objectStore(STORE_NAME)
-    const request = store.add(listenLaterItem)
-
-    request.onsuccess = () => {
-      resolve(listenLaterItem)
-    }
-
-    request.onerror = () => {
-      reject(new Error(`Failed to add item: ${request.error?.message}`))
-    }
-  })
-}
-
-/**
- * Removes an item from the listen later list
- */
-export function removeItem(db: IDBDatabase, itemId: string | number): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readwrite')
-    const store = transaction.objectStore(STORE_NAME)
-    const request = store.delete(itemId)
-
-    request.onsuccess = () => {
-      resolve()
-    }
-
-    request.onerror = () => {
-      reject(new Error(`Failed to remove item: ${request.error?.message}`))
-    }
-  })
-}
-
-/**
- * Toggles the hasBeenListened status of an item
- */
-export function toggleItemListened(
-  db: IDBDatabase,
-  itemId: string | number
-): Promise<ListenLaterItem | null> {
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readwrite')
-    const store = transaction.objectStore(STORE_NAME)
-    const getRequest = store.get(itemId)
-
-    getRequest.onsuccess = () => {
-      const item = getRequest.result
-      if (!item) {
-        resolve(null)
-        return
-      }
-
-      item.hasBeenListened = !item.hasBeenListened
-      const updateRequest = store.put(item)
-
-      updateRequest.onsuccess = () => {
-        resolve(item)
-      }
-
-      updateRequest.onerror = () => {
-        reject(new Error(`Failed to update item: ${updateRequest.error?.message}`))
-      }
-    }
-
-    getRequest.onerror = () => {
-      reject(new Error(`Failed to get item: ${getRequest.error?.message}`))
-    }
-  })
-}
-
-/**
- * Checks if an item exists in the listen later list
- */
-export function itemExists(db: IDBDatabase, itemId: string | number): Promise<boolean> {
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readonly')
-    const store = transaction.objectStore(STORE_NAME)
-    const request = store.get(itemId)
-
-    request.onsuccess = () => {
-      resolve(request.result !== undefined)
-    }
-
-    request.onerror = () => {
-      reject(new Error(`Failed to check item existence: ${request.error?.message}`))
-    }
-  })
-}
-
-/**
- * Gets the count of items in the listen later list
- */
-export function getItemCount(db: IDBDatabase): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readonly')
-    const store = transaction.objectStore(STORE_NAME)
-    const request = store.count()
-
-    request.onsuccess = () => {
-      resolve(request.result)
-    }
-
-    request.onerror = () => {
-      reject(new Error(`Failed to count items: ${request.error?.message}`))
-    }
-  })
-}
 
 export const DB_CONFIG = {
   name: DB_NAME,
   version: DB_VERSION,
   storeName: STORE_NAME,
 }
+
+/**
+ * What a caller has to provide to save an item. The store owns `addedAt` and
+ * `hasBeenListened`, so callers cannot disagree about them.
+ */
+export type NewListenLaterItem = Omit<ListenLaterItemProperties, 'hasBeenListened' | 'addedAt'>
+
+export interface ListenLaterStorage {
+  getAll(): Promise<ListenLaterItem[]>
+  get(itemId: string | number): Promise<ListenLaterItem | null>
+  add(input: NewListenLaterItem): Promise<ListenLaterItem>
+  remove(itemId: string | number): Promise<void>
+  toggleListened(itemId: string | number): Promise<ListenLaterItem | null>
+  updateExternalLinks(
+    itemId: string | number,
+    externalLinks: ExternalLink[]
+  ): Promise<ListenLaterItem | null>
+}
+
+/**
+ * Sorts items oldest first.
+ *
+ * Items written before version 2 carry a numeric `addedAt` (a migration
+ * counter) instead of a Date. Those integers are far below any epoch
+ * millisecond, so legacy items keep sorting before dated ones.
+ */
+function sortListenLaterItems(items: ListenLaterItem[]): ListenLaterItem[] {
+  return [...items].sort((a, b) => {
+    const aTime = a.addedAt instanceof Date ? a.addedAt.getTime() : (a.addedAt as unknown as number)
+    const bTime = b.addedAt instanceof Date ? b.addedAt.getTime() : (b.addedAt as unknown as number)
+    return (aTime || 0) - (bTime || 0)
+  })
+}
+
+/**
+ * Finds an item that is the same recording as the one described.
+ *
+ * Same title and the *same set* of artists. A shared title with a different
+ * artist set is another version, not a duplicate: "Nightcall" by Kavinsky and
+ * "Nightcall" by Kavinsky, Angèle & Phoenix are two different recordings, and
+ * a remix or a guest version does not always say so in its title.
+ */
+export function findDuplicate(
+  items: ListenLaterItem[],
+  title: string,
+  artists: string[]
+): ListenLaterItem | null {
+  const normalizedTitle = title.toLowerCase().trim()
+  const normalizedArtists = [
+    ...new Set(artists.map((artist) => artist.toLowerCase().trim())),
+  ].sort()
+
+  return (
+    items.find((item) => {
+      if (item.title.toLowerCase().trim() !== normalizedTitle) return false
+
+      const itemArtists = [
+        ...new Set(item.artists.map((artist) => artist.toLowerCase().trim())),
+      ].sort()
+      if (itemArtists.length !== normalizedArtists.length) return false
+
+      return itemArtists.every((artist, index) => artist === normalizedArtists[index])
+    }) ?? null
+  )
+}
+
+function openDatabase(indexedDBInstance: IDBFactory): Promise<IDBDatabase> {
+  const { promise, resolve, reject } = Promise.withResolvers<IDBDatabase>()
+  const request = indexedDBInstance.open(DB_NAME, DB_VERSION)
+
+  request.onerror = () => reject(new Error(`Failed to open database: ${request.error?.message}`))
+  request.onsuccess = () => resolve(request.result)
+
+  request.onupgradeneeded = (event: IDBVersionChangeEvent) => {
+    const db = (event.target as IDBOpenDBRequest).result
+    const oldVersion = event.oldVersion
+
+    // Create object store for fresh installs
+    if (oldVersion < 1) {
+      db.createObjectStore(STORE_NAME, {
+        keyPath: 'id',
+        autoIncrement: true,
+      })
+    }
+
+    // Migration from version 1 to 2: add type field to existing items
+    if (oldVersion < 2 && oldVersion >= 1) {
+      const transaction = (event.target as IDBOpenDBRequest).transaction
+      if (transaction) {
+        const objectStore = transaction.objectStore(STORE_NAME)
+        let counter = 0
+
+        objectStore.openCursor().onsuccess = (cursorEvent) => {
+          const cursor = (cursorEvent.target as IDBRequest<IDBCursorWithValue>).result
+          if (cursor) {
+            const item = cursor.value
+            // Add type field to existing items (default to 'track')
+            if (!item.type) {
+              item.type = 'track'
+            }
+            // Add addedAt field to existing items (use counter to preserve order)
+            if (!item.addedAt) {
+              item.addedAt = counter++
+            }
+            cursor.update(item)
+            cursor.continue()
+          }
+        }
+      }
+    }
+
+    // Migration from version 2 to 3: backfill externalLinks = [] on existing items
+    if (oldVersion < 3 && oldVersion >= 2) {
+      const transaction = (event.target as IDBOpenDBRequest).transaction
+      if (transaction) {
+        const objectStore = transaction.objectStore(STORE_NAME)
+
+        objectStore.openCursor().onsuccess = (cursorEvent) => {
+          const cursor = (cursorEvent.target as IDBRequest<IDBCursorWithValue>).result
+          if (cursor) {
+            const item = cursor.value
+            if (!item.externalLinks) {
+              item.externalLinks = []
+              const updateReq = cursor.update(item)
+              updateReq.onerror = () => {
+                console.error(
+                  'Failed to backfill externalLinks for item %o:',
+                  item.id,
+                  updateReq.error
+                )
+              }
+            }
+            cursor.continue()
+          }
+        }
+      }
+    }
+  }
+
+  return promise
+}
+
+// Five call sites open a transaction on the one object store; naming it keeps
+// STORE_NAME in a single place and reads as the intent, not the ceremony.
+const storeFor = (db: IDBDatabase, mode: IDBTransactionMode) =>
+  db.transaction(STORE_NAME, mode).objectStore(STORE_NAME)
+
+function getAllItems(db: IDBDatabase): Promise<ListenLaterItem[]> {
+  const { promise, resolve, reject } = Promise.withResolvers<ListenLaterItem[]>()
+  const request = storeFor(db, 'readonly').getAll()
+
+  request.onsuccess = () => resolve(sortListenLaterItems(request.result))
+  request.onerror = () => reject(new Error(`Failed to get items: ${request.error?.message}`))
+
+  return promise
+}
+
+function getItem(db: IDBDatabase, itemId: string | number): Promise<ListenLaterItem | null> {
+  const { promise, resolve, reject } = Promise.withResolvers<ListenLaterItem | null>()
+  const request = storeFor(db, 'readonly').get(itemId)
+
+  request.onsuccess = () => resolve(request.result || null)
+  request.onerror = () => reject(new Error(`Failed to get item: ${request.error?.message}`))
+
+  return promise
+}
+
+function addItem(
+  db: IDBDatabase,
+  input: NewListenLaterItem,
+  addedAt: Date
+): Promise<ListenLaterItem> {
+  const { promise, resolve, reject } = Promise.withResolvers<ListenLaterItem>()
+
+  // Every field is copied explicitly and arrays are rebuilt: IndexedDB
+  // structured-clones what it is given and rejects Svelte's reactive proxies
+  // with a DataCloneError. Keeping that here means no caller has to know.
+  const item: ListenLaterItem = {
+    id: input.id,
+    title: input.title,
+    releaseDate: input.releaseDate,
+    length: input.length,
+    artists: [...input.artists],
+    albumName: input.albumName,
+    itemType: input.itemType,
+    coverArt: input.coverArt,
+    hasBeenListened: false,
+    addedAt,
+    sourceUrl: input.sourceUrl,
+    externalLinks: (input.externalLinks ?? []).map((link) => ({ ...link })),
+  }
+
+  const request = storeFor(db, 'readwrite').add(item)
+
+  request.onsuccess = () => resolve(item)
+  request.onerror = () => reject(new Error(`Failed to add item: ${request.error?.message}`))
+
+  return promise
+}
+
+function removeItem(db: IDBDatabase, itemId: string | number): Promise<void> {
+  const { promise, resolve, reject } = Promise.withResolvers<void>()
+  const request = storeFor(db, 'readwrite').delete(itemId)
+
+  request.onsuccess = () => resolve()
+  request.onerror = () => reject(new Error(`Failed to remove item: ${request.error?.message}`))
+
+  return promise
+}
+
+function toggleItemListened(
+  db: IDBDatabase,
+  itemId: string | number
+): Promise<ListenLaterItem | null> {
+  const { promise, resolve, reject } = Promise.withResolvers<ListenLaterItem | null>()
+
+  // One readwrite transaction for the read and the write, so the flip cannot
+  // interleave with another writer.
+  const store = storeFor(db, 'readwrite')
+  const getRequest = store.get(itemId)
+
+  getRequest.onsuccess = () => {
+    const item = getRequest.result
+    if (!item) {
+      resolve(null)
+      return
+    }
+
+    item.hasBeenListened = !item.hasBeenListened
+    const updateRequest = store.put(item)
+
+    updateRequest.onsuccess = () => resolve(item)
+    updateRequest.onerror = () =>
+      reject(new Error(`Failed to update item: ${updateRequest.error?.message}`))
+  }
+
+  getRequest.onerror = () => reject(new Error(`Failed to get item: ${getRequest.error?.message}`))
+
+  return promise
+}
+
+/**
+ * Replaces an item's external links. Resolves `null` when the item is gone —
+ * link resolution takes seconds, and the user can remove the row while it runs.
+ */
+function updateItemExternalLinks(
+  db: IDBDatabase,
+  itemId: string | number,
+  externalLinks: ExternalLink[]
+): Promise<ListenLaterItem | null> {
+  const { promise, resolve, reject } = Promise.withResolvers<ListenLaterItem | null>()
+
+  const store = storeFor(db, 'readwrite')
+  const getRequest = store.get(itemId)
+
+  getRequest.onsuccess = () => {
+    const item = getRequest.result
+    if (!item) {
+      resolve(null)
+      return
+    }
+
+    // Rebuilt for the same reason `addItem` rebuilds arrays: a Svelte proxy
+    // reaching IndexedDB throws a DataCloneError.
+    item.externalLinks = externalLinks.map((link) => ({ ...link }))
+    const updateRequest = store.put(item)
+
+    updateRequest.onsuccess = () => resolve(item)
+    updateRequest.onerror = () =>
+      reject(new Error(`Failed to update item: ${updateRequest.error?.message}`))
+  }
+
+  getRequest.onerror = () => reject(new Error(`Failed to get item: ${getRequest.error?.message}`))
+
+  return promise
+}
+
+/**
+ * The only way to reach the Listen Later List. Owns the database name, the
+ * version, the migrations, the transactions and the sort order; never hands out
+ * an `IDBDatabase`.
+ *
+ * The connection opens on first use and is reused. `indexedDBInstance` is left
+ * unresolved until then, so importing this module is safe during SSR.
+ *
+ * `now` exists because two items added in the same millisecond sort in an
+ * unspecified order. A UI cannot produce that, a test can — so tests inject a
+ * sequenced clock instead of sleeping between writes.
+ */
+export function createListenLaterStorage(
+  indexedDBInstance?: IDBFactory,
+  now: () => Date = () => new Date()
+): ListenLaterStorage {
+  let connection: Promise<IDBDatabase> | null = null
+
+  const db = () => (connection ??= openDatabase(indexedDBInstance ?? indexedDB))
+
+  return {
+    async getAll() {
+      return getAllItems(await db())
+    },
+
+    async get(itemId) {
+      return getItem(await db(), itemId)
+    },
+
+    async add(input) {
+      return addItem(await db(), input, now())
+    },
+
+    async remove(itemId) {
+      return removeItem(await db(), itemId)
+    },
+
+    async toggleListened(itemId) {
+      return toggleItemListened(await db(), itemId)
+    },
+
+    async updateExternalLinks(itemId, externalLinks) {
+      return updateItemExternalLinks(await db(), itemId, externalLinks)
+    },
+  }
+}
+
+/** Shared instance: one connection for every caller in the browser. */
+export const listenLaterStorage = createListenLaterStorage()

--- a/tests/e2e/listen_later.spec.ts
+++ b/tests/e2e/listen_later.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test'
 import type { Locator, Page } from '@playwright/test'
+import { DB_CONFIG } from '../../src/infrastructure/storage/listen_later_storage.js'
 
 const SPOTIFY_URL = 'https://open.spotify.com/track/4uLU6hMCjMI75M1A2tKUQC'
 
@@ -96,30 +97,36 @@ async function addSpotifyItem(page: Page) {
   await expect(page.getByRole('dialog')).not.toBeVisible()
 }
 async function seedListenLaterItems(page: Page, items: ListenLaterItemSeed[]) {
-  await page.evaluate(async (seed) => {
-    const db = await new Promise<IDBDatabase>((resolve, reject) => {
-      const request = indexedDB.open('listenLaterDB', 3)
+  // The evaluate body runs in the browser and cannot import the store, so the
+  // schema is passed in: DB_CONFIG stays the single source of the name and
+  // version, and a bump cannot leave this seed opening an older database.
+  await page.evaluate(
+    async ({ config, seed }) => {
+      const opening = Promise.withResolvers<IDBDatabase>()
+      const request = indexedDB.open(config.name, config.version)
       request.onupgradeneeded = () => {
         const database = request.result
-        if (!database.objectStoreNames.contains('listenLaterList')) {
-          database.createObjectStore('listenLaterList', { keyPath: 'id', autoIncrement: true })
+        if (!database.objectStoreNames.contains(config.storeName)) {
+          database.createObjectStore(config.storeName, { keyPath: 'id', autoIncrement: true })
         }
       }
-      request.onsuccess = () => resolve(request.result)
-      request.onerror = () => reject(request.error)
-    })
+      request.onsuccess = () => opening.resolve(request.result)
+      request.onerror = () => opening.reject(request.error)
+      const db = await opening.promise
 
-    await new Promise<void>((resolve, reject) => {
-      const transaction = db.transaction('listenLaterList', 'readwrite')
-      const store = transaction.objectStore('listenLaterList')
+      const writing = Promise.withResolvers<void>()
+      const transaction = db.transaction(config.storeName, 'readwrite')
+      const store = transaction.objectStore(config.storeName)
       store.clear()
       for (const item of seed) store.add(item)
-      transaction.oncomplete = () => resolve()
-      transaction.onerror = () => reject(transaction.error)
-    })
+      transaction.oncomplete = () => writing.resolve()
+      transaction.onerror = () => writing.reject(transaction.error)
+      await writing.promise
 
-    db.close()
-  }, items)
+      db.close()
+    },
+    { config: DB_CONFIG, seed: items }
+  )
   await page.reload()
 }
 
@@ -557,6 +564,56 @@ test.describe('artist-only search', () => {
     const requestUrl = new URL(searchUrls[0])
     expect(requestUrl.searchParams.get('artist')).toBe('angele')
     expect(requestUrl.searchParams.has('q')).toBe(false)
+  })
+})
+
+test.describe('search results - add and remove', () => {
+  test('adding then removing from the search results toasts and updates the list', async ({
+    page,
+  }) => {
+    await page.route('**/api/links*', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ externalLinks: [] }),
+      })
+    })
+
+    await page.route('**/library/listen-later*', async (route) => {
+      const url = new URL(route.request().url())
+
+      if (!url.searchParams.has('type')) {
+        await route.continue()
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ serializedItems: [mockMetadataResponse.musicItem] }),
+      })
+    })
+
+    await page.goto('/library/listen-later')
+    await page.getByLabel('Artist name', { exact: true }).fill('Rick Astley')
+
+    const searchResult = page.getByRole('option', {
+      name: 'Add Never Gonna Give You Up to listen later',
+    })
+    await searchResult.click()
+
+    await expect(page.getByText('"Never Gonna Give You Up" added to your list')).toBeVisible()
+
+    const itemRow = page.getByRole('row').filter({ hasText: 'Never Gonna Give You Up' })
+    await expect(itemRow).toBeVisible()
+
+    const savedResult = page.getByRole('option', {
+      name: 'Remove Never Gonna Give You Up from listen later',
+    })
+    await savedResult.click()
+
+    await expect(page.getByText('"Never Gonna Give You Up" removed from your list')).toBeVisible()
+    await expect(itemRow).not.toBeVisible()
   })
 })
 

--- a/tests/unit/infrastructure/storage/listen_later_storage.spec.ts
+++ b/tests/unit/infrastructure/storage/listen_later_storage.spec.ts
@@ -1,24 +1,42 @@
 import 'fake-indexeddb/auto'
 import { test } from '@japa/runner'
-import { SearchType } from '../../../../src/domain/music_item.js'
 import {
-  openDatabase,
-  getAllItems,
-  getItem,
-  addItem,
-  removeItem,
-  toggleItemListened,
-  itemExists,
-  getItemCount,
-  createListenLaterItem,
-  sortListenLaterItems,
+  ListenLaterItem,
+  SearchType,
+  type ExternalLink,
+} from '../../../../src/domain/music_item.js'
+import {
+  createListenLaterStorage,
+  findDuplicate,
   DB_CONFIG,
+  type NewListenLaterItem,
 } from '../../../../src/infrastructure/storage/listen_later_storage.js'
 
-// Helper to create a test MusicItem
-function createTestMusicItem(overrides = {}) {
+/**
+ * One store for the whole file: the factory opens a connection lazily and keeps
+ * it, so deleting the database between tests would be blocked by that
+ * connection. Emptying the list through the interface isolates tests without
+ * ever racing a close.
+ *
+ * The clock is sequenced, one second per write: two items added in the same
+ * millisecond sort in an unspecified order, which is what made order assertions
+ * flaky when they leaned on real time.
+ */
+let tick = 0
+const storage = createListenLaterStorage(
+  indexedDB,
+  () => new Date(1_700_000_000_000 + tick++ * 1000)
+)
+
+async function emptyList() {
+  for (const item of await storage.getAll()) {
+    await storage.remove(item.id)
+  }
+}
+
+function describeItem(overrides: Partial<NewListenLaterItem> = {}): NewListenLaterItem {
   return {
-    id: `test-id-${Date.now()}-${Math.random()}`,
+    id: 'test-id',
     title: 'Test Track',
     releaseDate: '2024-01-15',
     artists: ['Test Artist'],
@@ -29,485 +47,301 @@ function createTestMusicItem(overrides = {}) {
   }
 }
 
-// Clean up IndexedDB between tests
-async function cleanupDatabase() {
-  const deleteRequest = indexedDB.deleteDatabase(DB_CONFIG.name)
-  await new Promise<void>((resolve, reject) => {
-    deleteRequest.onsuccess = () => resolve()
-    deleteRequest.onerror = () => reject(deleteRequest.error)
+/**
+ * Writes a row the way versions before 2 did: `addedAt` as a migration counter
+ * instead of a Date. Only the migration ever produces these, so the store's own
+ * `add` cannot.
+ */
+async function seedLegacyRow(id: string, title: string, addedAt: number) {
+  const { promise, resolve, reject } = Promise.withResolvers<IDBDatabase>()
+  const request = indexedDB.open(DB_CONFIG.name, DB_CONFIG.version)
+  request.onsuccess = () => resolve(request.result)
+  request.onerror = () => reject(request.error)
+  const db = await promise
+
+  const write = Promise.withResolvers<void>()
+  const transaction = db.transaction(DB_CONFIG.storeName, 'readwrite')
+  transaction.objectStore(DB_CONFIG.storeName).add({
+    id,
+    title,
+    releaseDate: '2020-01-01',
+    artists: ['Legacy Artist'],
+    itemType: SearchType.track,
+    hasBeenListened: false,
+    addedAt,
   })
+  transaction.oncomplete = () => write.resolve()
+  transaction.onerror = () => write.reject(transaction.error)
+  await write.promise
+
+  db.close()
 }
 
-test.group('Listen Later Storage - Database Operations', (group) => {
-  group.each.teardown(async () => {
-    await cleanupDatabase()
+test.group('Listen Later Storage - writes', (group) => {
+  group.each.teardown(emptyList)
+
+  test('add stores the described item and owns addedAt and hasBeenListened', async ({ assert }) => {
+    const stored = await storage.add(describeItem({ id: 'add-test-1' }))
+
+    assert.equal(stored.id, 'add-test-1')
+    assert.equal(stored.title, 'Test Track')
+    assert.deepEqual(stored.artists, ['Test Artist'])
+    assert.isFalse(stored.hasBeenListened)
+    assert.instanceOf(stored.addedAt, Date)
   })
 
-  test('openDatabase creates and opens the database successfully', async ({ assert }) => {
-    const db = await openDatabase()
+  test('add keeps sourceUrl and externalLinks', async ({ assert }) => {
+    await storage.add(
+      describeItem({
+        id: 'add-test-2',
+        sourceUrl: 'https://open.spotify.com/track/abc',
+        externalLinks: [
+          {
+            platform: 'deezer',
+            label: 'Deezer',
+            url: 'https://deezer.com/track/1',
+            category: 'stream',
+            source: 'platform-search',
+          },
+        ],
+      })
+    )
 
-    assert.isNotNull(db)
-    assert.equal(db.name, DB_CONFIG.name)
-    assert.equal(db.version, DB_CONFIG.version)
-    assert.isTrue(db.objectStoreNames.contains(DB_CONFIG.storeName))
+    const result = await storage.get('add-test-2')
 
-    db.close()
+    assert.equal(result!.sourceUrl, 'https://open.spotify.com/track/abc')
+    assert.lengthOf(result!.externalLinks!, 1)
+    assert.equal(result!.externalLinks![0].platform, 'deezer')
   })
 
-  test('openDatabase creates object store with correct configuration', async ({ assert }) => {
-    const db = await openDatabase()
+  test('add defaults externalLinks to an empty array', async ({ assert }) => {
+    await storage.add(describeItem({ id: 'add-test-3' }))
 
-    const transaction = db.transaction(DB_CONFIG.storeName, 'readonly')
-    const store = transaction.objectStore(DB_CONFIG.storeName)
+    const result = await storage.get('add-test-3')
 
-    assert.equal(store.keyPath, 'id')
-    assert.isTrue(store.autoIncrement)
+    assert.deepEqual(result!.externalLinks, [])
+  })
 
-    db.close()
+  test('add stores a structured-cloneable copy, not the caller object', async ({ assert }) => {
+    const artists = ['Kavinsky']
+    const input = describeItem({ id: 'add-test-4', artists })
+
+    const stored = await storage.add(input)
+    artists.push('Mutated After Save')
+
+    assert.deepEqual(stored.artists, ['Kavinsky'])
+    assert.deepEqual((await storage.get('add-test-4'))!.artists, ['Kavinsky'])
+  })
+
+  test('remove deletes the item', async ({ assert }) => {
+    await storage.add(describeItem({ id: 'remove-test-1' }))
+
+    await storage.remove('remove-test-1')
+
+    assert.isNull(await storage.get('remove-test-1'))
+  })
+
+  test('toggleListened flips the flag and returns the updated item', async ({ assert }) => {
+    await storage.add(describeItem({ id: 'toggle-test-1' }))
+
+    const listened = await storage.toggleListened('toggle-test-1')
+    assert.isTrue(listened!.hasBeenListened)
+
+    const unlistened = await storage.toggleListened('toggle-test-1')
+    assert.isFalse(unlistened!.hasBeenListened)
+  })
+
+  test('toggleListened persists the new value', async ({ assert }) => {
+    await storage.add(describeItem({ id: 'toggle-test-2' }))
+
+    await storage.toggleListened('toggle-test-2')
+
+    assert.isTrue((await storage.get('toggle-test-2'))!.hasBeenListened)
+  })
+
+  test('toggleListened returns null for an unknown id', async ({ assert }) => {
+    assert.isNull(await storage.toggleListened('non-existent-id'))
+  })
+
+  const deezerLink: ExternalLink = {
+    platform: 'deezer',
+    label: 'Deezer',
+    url: 'https://deezer.com/track/1',
+    category: 'stream',
+    source: 'platform-search',
+  }
+
+  test('updateExternalLinks replaces the links and persists them', async ({ assert }) => {
+    await storage.add(describeItem({ id: 'links-test-1' }))
+
+    const updated = await storage.updateExternalLinks('links-test-1', [deezerLink])
+
+    assert.isNotNull(updated)
+    assert.lengthOf(updated!.externalLinks!, 1)
+    assert.equal((await storage.get('links-test-1'))!.externalLinks![0].platform, 'deezer')
+  })
+
+  test('updateExternalLinks returns null when the item was removed', async ({ assert }) => {
+    assert.isNull(await storage.updateExternalLinks('non-existent-id', [deezerLink]))
+  })
+
+  test('get returns null for an unknown id', async ({ assert }) => {
+    assert.isNull(await storage.get('non-existent-id'))
   })
 })
 
-test.group('Listen Later Storage - CRUD Operations', (group) => {
-  let db: IDBDatabase
+test.group('Listen Later Storage - reads', (group) => {
+  group.each.teardown(emptyList)
 
-  group.each.setup(async () => {
-    db = await openDatabase()
-  })
-
-  group.each.teardown(async () => {
-    db.close()
-    await cleanupDatabase()
-  })
-
-  test('addItem adds a music item to the database', async ({ assert }) => {
-    const musicItem = createTestMusicItem({ id: 'add-test-1' })
-
-    const result = await addItem(db, musicItem)
-
-    assert.equal(result.id, musicItem.id)
-    assert.equal(result.title, musicItem.title)
-    assert.equal(result.hasBeenListened, false)
-    assert.instanceOf(result.addedAt, Date)
-  })
-
-  test('getItem retrieves an item by ID', async ({ assert }) => {
-    const musicItem = createTestMusicItem({ id: 'get-test-1' })
-    await addItem(db, musicItem)
-
-    const result = await getItem(db, 'get-test-1')
-
-    assert.isNotNull(result)
-    assert.equal(result!.id, 'get-test-1')
-    assert.equal(result!.title, musicItem.title)
-  })
-
-  test('getItem returns null for non-existent item', async ({ assert }) => {
-    const result = await getItem(db, 'non-existent-id')
-
-    assert.isNull(result)
-  })
-
-  test('getAllItems returns all items sorted by addedAt', async ({ assert }) => {
-    const item1 = createTestMusicItem({ id: 'all-test-1', title: 'First' })
-    const item2 = createTestMusicItem({ id: 'all-test-2', title: 'Second' })
-    const item3 = createTestMusicItem({ id: 'all-test-3', title: 'Third' })
-
-    await addItem(db, item1)
-    // Small delay to ensure different timestamps
-    await new Promise((resolve) => setTimeout(resolve, 10))
-    await addItem(db, item2)
-    await new Promise((resolve) => setTimeout(resolve, 10))
-    await addItem(db, item3)
-
-    const results = await getAllItems(db)
-
-    assert.lengthOf(results, 3)
-    assert.equal(results[0].title, 'First')
-    assert.equal(results[1].title, 'Second')
-    assert.equal(results[2].title, 'Third')
-  })
-
-  test('getAllItems returns empty array when no items exist', async ({ assert }) => {
-    const results = await getAllItems(db)
+  test('getAll returns an empty array when nothing is stored', async ({ assert }) => {
+    const results = await storage.getAll()
 
     assert.isArray(results)
     assert.lengthOf(results, 0)
   })
 
-  test('removeItem deletes an item from the database', async ({ assert }) => {
-    const musicItem = createTestMusicItem({ id: 'remove-test-1' })
-    await addItem(db, musicItem)
+  test('getAll returns items oldest first', async ({ assert }) => {
+    await storage.add(describeItem({ id: 'order-1', title: 'First' }))
+    await storage.add(describeItem({ id: 'order-2', title: 'Second' }))
+    await storage.add(describeItem({ id: 'order-3', title: 'Third' }))
 
-    // Verify item exists
-    let exists = await itemExists(db, 'remove-test-1')
-    assert.isTrue(exists)
+    const stored = await storage.getAll()
+    const titles = stored.map((item) => item.title)
 
-    // Remove item
-    await removeItem(db, 'remove-test-1')
-
-    // Verify item is removed
-    exists = await itemExists(db, 'remove-test-1')
-    assert.isFalse(exists)
+    assert.deepEqual(titles, ['First', 'Second', 'Third'])
   })
 
-  test('toggleItemListened toggles hasBeenListened from false to true', async ({ assert }) => {
-    const musicItem = createTestMusicItem({ id: 'toggle-test-1' })
-    await addItem(db, musicItem)
+  test('getAll sorts regardless of insertion order', async ({ assert }) => {
+    // Keys sort before addedAt would, so ids are deliberately reversed.
+    await storage.add(describeItem({ id: 'zzz', title: 'First' }))
+    await storage.add(describeItem({ id: 'aaa', title: 'Second' }))
 
-    const result = await toggleItemListened(db, 'toggle-test-1')
+    const stored = await storage.getAll()
+    const titles = stored.map((item) => item.title)
 
-    assert.isNotNull(result)
-    assert.equal(result!.hasBeenListened, true)
+    assert.deepEqual(titles, ['First', 'Second'])
   })
 
-  test('toggleItemListened toggles hasBeenListened from true to false', async ({ assert }) => {
-    const musicItem = createTestMusicItem({ id: 'toggle-test-2' })
-    await addItem(db, musicItem)
+  test('getAll sorts legacy numeric addedAt before dated items', async ({ assert }) => {
+    await storage.add(describeItem({ id: 'modern', title: 'Modern' }))
+    await seedLegacyRow('legacy-2', 'Legacy Two', 2)
+    await seedLegacyRow('legacy-1', 'Legacy One', 1)
 
-    // Toggle to true
-    await toggleItemListened(db, 'toggle-test-2')
-    // Toggle back to false
-    const result = await toggleItemListened(db, 'toggle-test-2')
+    const stored = await storage.getAll()
+    const titles = stored.map((item) => item.title)
 
-    assert.isNotNull(result)
-    assert.equal(result!.hasBeenListened, false)
+    assert.deepEqual(titles, ['Legacy One', 'Legacy Two', 'Modern'])
   })
 
-  test('toggleItemListened returns null for non-existent item', async ({ assert }) => {
-    const result = await toggleItemListened(db, 'non-existent-id')
+  test('stores both track and album items', async ({ assert }) => {
+    await storage.add(
+      describeItem({ id: 'track-type', itemType: SearchType.track, albumName: 'Greatest Hits' })
+    )
+    await storage.add(
+      describeItem({ id: 'album-type', itemType: SearchType.album, title: 'Amazing Album' })
+    )
 
-    assert.isNull(result)
+    assert.equal((await storage.get('track-type'))!.itemType, SearchType.track)
+    assert.equal((await storage.get('track-type'))!.albumName, 'Greatest Hits')
+    assert.equal((await storage.get('album-type'))!.itemType, SearchType.album)
   })
 
-  test('itemExists returns true for existing item', async ({ assert }) => {
-    const musicItem = createTestMusicItem({ id: 'exists-test-1' })
-    await addItem(db, musicItem)
+  test('stores multiple artists', async ({ assert }) => {
+    await storage.add(
+      describeItem({ id: 'multi-artist', artists: ['Artist One', 'Artist Two', 'Artist Three'] })
+    )
 
-    const exists = await itemExists(db, 'exists-test-1')
+    const result = await storage.get('multi-artist')
 
-    assert.isTrue(exists)
-  })
-
-  test('itemExists returns false for non-existent item', async ({ assert }) => {
-    const exists = await itemExists(db, 'non-existent-id')
-
-    assert.isFalse(exists)
-  })
-
-  test('getItemCount returns correct count', async ({ assert }) => {
-    // Initially empty
-    let count = await getItemCount(db)
-    assert.equal(count, 0)
-
-    // Add items
-    await addItem(db, createTestMusicItem({ id: 'count-test-1' }))
-    await addItem(db, createTestMusicItem({ id: 'count-test-2' }))
-    await addItem(db, createTestMusicItem({ id: 'count-test-3' }))
-
-    count = await getItemCount(db)
-    assert.equal(count, 3)
-
-    // Remove one item
-    await removeItem(db, 'count-test-2')
-
-    count = await getItemCount(db)
-    assert.equal(count, 2)
-  })
-})
-
-test.group('Listen Later Storage - Helper Functions', () => {
-  test('createListenLaterItem creates item with correct properties', async ({ assert }) => {
-    const musicItem = createTestMusicItem({ id: 'helper-test-1' })
-
-    const listenLaterItem = createListenLaterItem(musicItem)
-
-    assert.equal(listenLaterItem.id, musicItem.id)
-    assert.equal(listenLaterItem.title, musicItem.title)
-    assert.deepEqual(listenLaterItem.artists, musicItem.artists)
-    assert.equal(listenLaterItem.hasBeenListened, false)
-    assert.instanceOf(listenLaterItem.addedAt, Date)
-  })
-
-  test('sortListenLaterItems sorts by Date objects in ascending order', async ({ assert }) => {
-    const items = [
-      {
-        id: '3',
-        title: 'Third',
-        releaseDate: '2024-01-01',
-        artists: ['Artist'],
-        itemType: SearchType.track,
-        hasBeenListened: false,
-        addedAt: new Date('2024-01-03'),
-      },
-      {
-        id: '1',
-        title: 'First',
-        releaseDate: '2024-01-01',
-        artists: ['Artist'],
-        itemType: SearchType.track,
-        hasBeenListened: false,
-        addedAt: new Date('2024-01-01'),
-      },
-      {
-        id: '2',
-        title: 'Second',
-        releaseDate: '2024-01-01',
-        artists: ['Artist'],
-        itemType: SearchType.track,
-        hasBeenListened: false,
-        addedAt: new Date('2024-01-02'),
-      },
-    ]
-
-    const sorted = sortListenLaterItems(items)
-
-    // Verify exact order - oldest first
-    assert.equal(sorted[0].title, 'First')
-    assert.equal(sorted[1].title, 'Second')
-    assert.equal(sorted[2].title, 'Third')
-
-    // Verify it's actually sorted by comparing timestamps
-    const firstTime = (sorted[0].addedAt as Date).getTime()
-    const secondTime = (sorted[1].addedAt as Date).getTime()
-    const thirdTime = (sorted[2].addedAt as Date).getTime()
-    assert.isTrue(firstTime < secondTime, 'First item should have earlier timestamp than second')
-    assert.isTrue(secondTime < thirdTime, 'Second item should have earlier timestamp than third')
-  })
-
-  test('sortListenLaterItems returns items in ascending order (oldest first)', async ({
-    assert,
-  }) => {
-    // This test uses items that would fail if sort is broken (e.g., reversed or unsorted)
-    const oldest = {
-      id: 'oldest',
-      title: 'Oldest',
-      releaseDate: '2024-01-01',
-      artists: ['Artist'],
-      itemType: SearchType.track,
-      hasBeenListened: false,
-      addedAt: new Date('2020-01-01'),
-    }
-    const newest = {
-      id: 'newest',
-      title: 'Newest',
-      releaseDate: '2024-01-01',
-      artists: ['Artist'],
-      itemType: SearchType.track,
-      hasBeenListened: false,
-      addedAt: new Date('2025-01-01'),
-    }
-    const middle = {
-      id: 'middle',
-      title: 'Middle',
-      releaseDate: '2024-01-01',
-      artists: ['Artist'],
-      itemType: SearchType.track,
-      hasBeenListened: false,
-      addedAt: new Date('2022-06-15'),
-    }
-
-    // Input in random order
-    const items = [newest, oldest, middle]
-    const sorted = sortListenLaterItems(items)
-
-    // Must be: oldest, middle, newest
-    assert.equal(sorted[0].id, 'oldest')
-    assert.equal(sorted[1].id, 'middle')
-    assert.equal(sorted[2].id, 'newest')
-  })
-
-  test('sortListenLaterItems sorts by numeric timestamps (legacy data)', async ({ assert }) => {
-    const items = [
-      {
-        id: '3',
-        title: 'Third',
-        releaseDate: '2024-01-01',
-        artists: ['Artist'],
-        itemType: SearchType.track,
-        hasBeenListened: false,
-        addedAt: 3 as unknown as Date, // Legacy numeric format
-      },
-      {
-        id: '1',
-        title: 'First',
-        releaseDate: '2024-01-01',
-        artists: ['Artist'],
-        itemType: SearchType.track,
-        hasBeenListened: false,
-        addedAt: 1 as unknown as Date, // Legacy numeric format
-      },
-      {
-        id: '2',
-        title: 'Second',
-        releaseDate: '2024-01-01',
-        artists: ['Artist'],
-        itemType: SearchType.track,
-        hasBeenListened: false,
-        addedAt: 2 as unknown as Date, // Legacy numeric format
-      },
-    ]
-
-    const sorted = sortListenLaterItems(items)
-
-    assert.equal(sorted[0].title, 'First')
-    assert.equal(sorted[1].title, 'Second')
-    assert.equal(sorted[2].title, 'Third')
-  })
-
-  test('sortListenLaterItems handles empty array', async ({ assert }) => {
-    const sorted = sortListenLaterItems([])
-
-    assert.isArray(sorted)
-    assert.lengthOf(sorted, 0)
-  })
-
-  test('sortListenLaterItems does not mutate original array', async ({ assert }) => {
-    const items = [
-      {
-        id: '2',
-        title: 'Second',
-        releaseDate: '2024-01-01',
-        artists: ['Artist'],
-        itemType: SearchType.track,
-        hasBeenListened: false,
-        addedAt: new Date('2024-01-02'),
-      },
-      {
-        id: '1',
-        title: 'First',
-        releaseDate: '2024-01-01',
-        artists: ['Artist'],
-        itemType: SearchType.track,
-        hasBeenListened: false,
-        addedAt: new Date('2024-01-01'),
-      },
-    ]
-
-    const sorted = sortListenLaterItems(items)
-
-    // Original array should maintain order
-    assert.equal(items[0].title, 'Second')
-    assert.equal(items[1].title, 'First')
-
-    // Sorted array should be in order
-    assert.equal(sorted[0].title, 'First')
-    assert.equal(sorted[1].title, 'Second')
-  })
-})
-
-test.group('Listen Later Storage - Item Types', (group) => {
-  let db: IDBDatabase
-
-  group.each.setup(async () => {
-    db = await openDatabase()
-  })
-
-  group.each.teardown(async () => {
-    db.close()
-    await cleanupDatabase()
-  })
-
-  test('can add and retrieve track items', async ({ assert }) => {
-    const trackItem = createTestMusicItem({
-      id: 'track-type-test',
-      itemType: SearchType.track,
-      title: 'My Favorite Song',
-      albumName: 'Greatest Hits',
-    })
-
-    await addItem(db, trackItem)
-    const result = await getItem(db, 'track-type-test')
-
-    assert.isNotNull(result)
-    assert.equal(result!.itemType, SearchType.track)
-    assert.equal(result!.albumName, 'Greatest Hits')
-  })
-
-  test('can add and retrieve album items', async ({ assert }) => {
-    const albumItem = createTestMusicItem({
-      id: 'album-type-test',
-      itemType: SearchType.album,
-      title: 'Amazing Album',
-      albumName: 'Amazing Album',
-    })
-
-    await addItem(db, albumItem)
-    const result = await getItem(db, 'album-type-test')
-
-    assert.isNotNull(result)
-    assert.equal(result!.itemType, SearchType.album)
-    assert.equal(result!.title, 'Amazing Album')
-  })
-
-  test('can store items with multiple artists', async ({ assert }) => {
-    const multiArtistItem = createTestMusicItem({
-      id: 'multi-artist-test',
-      artists: ['Artist One', 'Artist Two', 'Artist Three'],
-    })
-
-    await addItem(db, multiArtistItem)
-    const result = await getItem(db, 'multi-artist-test')
-
-    assert.isNotNull(result)
     assert.deepEqual(result!.artists, ['Artist One', 'Artist Two', 'Artist Three'])
-    assert.lengthOf(result!.artists, 3)
-  })
-})
-
-test.group('Listen Later Storage - Edge Cases', (group) => {
-  let db: IDBDatabase
-
-  group.each.setup(async () => {
-    db = await openDatabase()
   })
 
-  group.each.teardown(async () => {
-    db.close()
-    await cleanupDatabase()
-  })
-
-  test('handles items without optional coverArt field', async ({ assert }) => {
-    const itemWithoutCover = {
-      id: 'no-cover-test',
-      title: 'No Cover Track',
-      releaseDate: '2024-01-01',
-      artists: ['Artist'],
-      itemType: SearchType.track,
-    }
-
-    await addItem(db, itemWithoutCover)
-    const result = await getItem(db, 'no-cover-test')
-
-    assert.isNotNull(result)
-    assert.isUndefined(result!.coverArt)
-  })
-
-  test('handles items without optional albumName field', async ({ assert }) => {
-    const itemWithoutAlbum = {
-      id: 'no-album-test',
+  test('stores items without optional fields', async ({ assert }) => {
+    await storage.add({
+      id: 'no-optionals',
       title: 'Single Track',
       releaseDate: '2024-01-01',
-      artists: ['Solo Artist'],
-      itemType: SearchType.track,
-    }
-
-    await addItem(db, itemWithoutAlbum)
-    const result = await getItem(db, 'no-album-test')
-
-    assert.isNotNull(result)
-    assert.isUndefined(result!.albumName)
-  })
-
-  test('handles empty artists array', async ({ assert }) => {
-    const itemWithNoArtists = createTestMusicItem({
-      id: 'no-artists-test',
       artists: [],
+      itemType: SearchType.track,
     })
 
-    await addItem(db, itemWithNoArtists)
-    const result = await getItem(db, 'no-artists-test')
+    const result = await storage.get('no-optionals')
 
-    assert.isNotNull(result)
+    assert.isUndefined(result!.coverArt)
+    assert.isUndefined(result!.albumName)
     assert.deepEqual(result!.artists, [])
+  })
+})
+
+test.group('Listen Later Storage - injection', () => {
+  test('createListenLaterStorage uses the IDBFactory it is given', async ({ assert }) => {
+    const injected = createListenLaterStorage(indexedDB)
+
+    await injected.add(describeItem({ id: 'injected-1' }))
+    assert.isNotNull(await injected.get('injected-1'))
+
+    await injected.remove('injected-1')
+  })
+})
+
+test.group('Listen Later Storage - duplicate rule', () => {
+  function item(title: string, artists: string[]): ListenLaterItem {
+    return {
+      id: `${title}-${artists.join('-')}`,
+      title,
+      releaseDate: '2024-01-01',
+      artists,
+      itemType: SearchType.track,
+      hasBeenListened: false,
+      addedAt: new Date(),
+    }
+  }
+
+  test('matches on identical title and artist set', ({ assert }) => {
+    const items = [item('Nightcall', ['Kavinsky'])]
+
+    const found = findDuplicate(items, 'Nightcall', ['Kavinsky'])
+
+    assert.equal(found!.id, 'Nightcall-Kavinsky')
+  })
+
+  test('ignores case and surrounding whitespace', ({ assert }) => {
+    const items = [item('Nightcall', ['Kavinsky'])]
+
+    assert.isNotNull(findDuplicate(items, '  NIGHTCALL ', [' kavinsky']))
+  })
+
+  test('ignores artist order', ({ assert }) => {
+    const items = [item('Nightcall', ['Kavinsky', 'Angèle'])]
+
+    assert.isNotNull(findDuplicate(items, 'Nightcall', ['Angèle', 'Kavinsky']))
+  })
+
+  test('a repeated artist name does not make it another version', ({ assert }) => {
+    const items = [item('Nightcall', ['Kavinsky', 'Kavinsky'])]
+
+    assert.isNotNull(findDuplicate(items, 'Nightcall', ['Kavinsky']))
+  })
+
+  test('a shared title with extra artists is another version, not a duplicate', ({ assert }) => {
+    const items = [item('Nightcall', ['Kavinsky'])]
+
+    assert.isNull(findDuplicate(items, 'Nightcall', ['Kavinsky', 'Angèle', 'Phoenix']))
+  })
+
+  test('a shared title with fewer artists is another version, not a duplicate', ({ assert }) => {
+    const items = [item('Nightcall', ['Kavinsky', 'Angèle', 'Phoenix'])]
+
+    assert.isNull(findDuplicate(items, 'Nightcall', ['Kavinsky']))
+  })
+
+  test('same artists but a different title is not a duplicate', ({ assert }) => {
+    const items = [item('Nightcall', ['Kavinsky'])]
+
+    assert.isNull(findDuplicate(items, 'Odd Look', ['Kavinsky']))
+  })
+
+  test('returns null on an empty list', ({ assert }) => {
+    assert.isNull(findDuplicate([], 'Nightcall', ['Kavinsky']))
   })
 })


### PR DESCRIPTION
Candidate 1 of the 4 August 2026 architecture survey, designed through a `/grill-with-docs` interview (eleven decisions) and reviewed on two axes before opening.

## The problem

The Listen Later List's persistence was hand-inlined as raw IndexedDB in two Svelte files across three `indexedDB.open('listenLaterDB', 3)` sites — while `src/infrastructure/storage/listen_later_storage.ts` declared a six-method `ListenLaterStorage` interface, with an injectable `IDBFactory` for headless testing, that **nothing implemented and no production file imported**. The interface was decorative; the module exported free functions each taking `db: IDBDatabase` as their first argument.

The two write paths did not even construct the same thing: the paste flow built a `new ListenLaterItem({...})` class instance, the search-results row built a plain object literal. The module's `add` could express neither — it derived the stored item itself and accepted no edited fields, no `sourceUrl`, no `externalLinks`.

## What changed

`createListenLaterStorage(indexedDB?, now?)` implements the interface and owns the database name, version 3, the migrations, the transactions, the sort order and the duplicate rule. It never hands out an `IDBDatabase`. The connection opens on first use and is reused; `indexedDB` stays unresolved until then, so importing the module is safe during SSR. One shared instance serves both callers — **one connection replaces three**.

`add` takes a description (`Omit<ListenLaterItemProperties, 'hasBeenListened' | 'addedAt'>`) rather than a finished item. The store owns `addedAt`, `hasBeenListened` and the structured-cloneable copy — every field copied explicitly, every array rebuilt. That last part is the invariant behind a `DataCloneError` this project already hit once, when IndexedDB rejected a Svelte-proxied array; it now lives behind the interface instead of being each caller's problem.

**Zero `indexedDB.open` in production code.** Three remain, all deliberate: the module itself, the unit spec (seeding one pre-v2 row), and the e2e seed, which now receives `DB_CONFIG` as a `page.evaluate` argument. The demo script keeps its literals with a comment pointing at the source of truth.

## Behaviour changes

**Duplicate detection now requires the same set of artists**, not one shared artist. This fixes a real false positive: *Nightcall* by Kavinsky and *Nightcall* by Kavinsky, Angèle & Phoenix are two different recordings, and a remix or guest version does not always say so in its title. The trade is deliberate — a false negative (the same recording credited differently by two sources) beats being blocked on a legitimate add. Comparison is order-insensitive and set-based, so a repeated artist name doesn't split the match.

**Adding or removing from the search results now shows a toast.** Only the paste flow had feedback; the quick-add row had none, not even on failure.

**Writes reject instead of logging and continuing.** Every caller catches, surfaces a toast, and leaves the in-memory list untouched on failure. Previously every error was a `console.error` and a silent no-op.

**Remove and toggle stop re-reading the whole list.** They update in memory like `add` always did — one storage operation per action instead of two. Recorded in `docs/adr/0001-optimistic-listen-later-updates.md`, along with the rejected alternative and the multi-tab ceiling.

## Two claims from the brief that did not survive the evidence

**The "add appends without sorting" defect does not exist** in the default view. `ListenLaterListTable` starts with no sort state, so TanStack preserves array order; the page pre-sorts oldest-first; appending puts the newest item last — exactly where a reload puts it. And once the user picks a sort, the table re-sorts anyway. The legacy `addedAt` fallback is harmless too: `(dateObj as number) || 0` yields the `Date`, whose subtraction coerces via `valueOf`, so mixed legacy/dated lists already sorted correctly.

**The intermittent unit failure was not what it looked like.** The suspicion was a same-millisecond collision between two writes separated by `setTimeout(…, 10)` — but 10ms guarantees a millisecond change. Reproduced during implementation: two adds in the *same* millisecond do leave the order unspecified, and the pre-existing order assertion passed only because insertion order happened to match key order. The sleeps hid it rather than removed it. Fixed by injecting a sequenced clock instead of sleeping, which also removed the sleeps. **Eight consecutive suite runs, all green.**

Teardown also stopped deleting the database — it empties the list through the interface — so a still-open connection can no longer block cleanup.

## Verification

- `pnpm run lint` clean, `pnpm run typecheck` clean
- **219 unit tests** pass, including 8 on the duplicate rule (both Nightcall directions, repeated names, empty list) and one asserting legacy numeric `addedAt` sorts before dated items
- **29 e2e tests** pass, including a new one covering add-then-remove from the search results — the `trackItem.svelte` path that had no coverage at all

## Review before opening

Two parallel sub-agents, Standards and Spec. Standards found no documented-standard breach; Spec found no scope creep. Three findings were acted on:

- `findDuplicate` compared artists as a multiset, so a repeated name would have counted as another version. Now set-based, with a test.
- The `db.transaction(STORE_NAME, mode).objectStore(STORE_NAME)` chain repeated five times → extracted as `storeFor`.
- The commit subject used "saved-items", a synonym `CONTEXT.md` explicitly tells us to avoid → reworded before pushing.

One suggestion was declined: a shared `toNewListenLaterItem` mapper across both callers. They build from different sources — one from a confirm dialog's edited fields, the other from a search result — so the mapper would need an extras bag to serve both, and the field list would still be written once per caller. Two explicit object literals are the shorter honest version.

## Closes

Closes #47 — *fix(ui): no toast when adding/removing an item from search results.* Both search-results paths now toast on success with the exact wording the dialog and table paths use (`trackItem.svelte:55`, `:85`).

Its fourth acceptance criterion, *"No toast fires on `onerror`"*, was amended rather than met. It was written when a failed write was a silent `console.error` no-op, so "no toast on error" meant "leave failure as it is". This PR changes failure itself: writes reject, callers catch, and the person gets a toast instead of nothing. A silent failure lets someone believe a Listen Later Item was saved when it was not. The amended criterion is on the issue.

## Not in this PR

- Wiring `offline_detector.ts` — #48. Its `isOffline` is a getter over a closed-over `let`, not a rune, so it cannot drive a Svelte 5 template; decision taken is to rewrite it as a runes store, which moves it out of `src/infrastructure/`.
- One row description, two layouts — #49
- Deleting the dead link-intake endpoints and `cache_config.ts` — #50
- Remaining survey candidates 3, 5, 6 — #51
- Typechecking the Svelte layer — #52. `tsconfig.json` excludes `inertia/**`, so neither caller in this PR is seen by `tsc`; their only automated coverage is Playwright.
